### PR TITLE
Update Error Handling for Node SDK 

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -7,7 +7,7 @@ import { GrantType } from './types/scalekit';
 import { ErrorInfo } from './pkg/grpc/scalekit/v1/errdetails/errdetails_pb';
 import { TokenResponse } from './types/auth';
 import { transformError } from './errors';
-import { ScalekitServerException, ScalekitClientException } from './errors/base-exception';
+import { ScalekitException, ScalekitServerException } from './errors/base-exception';
 
 export const headers = {
   "user-agent": "user-agent",

--- a/src/errors/base-exception.ts
+++ b/src/errors/base-exception.ts
@@ -1,56 +1,152 @@
 import { ConnectError, Code } from '@connectrpc/connect';
+import { AxiosResponse } from 'axios';
 import { ErrorInfo } from '../pkg/grpc/scalekit/v1/errdetails/errdetails_pb';
-import { GRPC_TO_HTTP_STATUS } from './grpc-codes';
 
-// Base client exception
-export class ScalekitClientException extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'ScalekitClientException';
+// gRPC to HTTP status mapping
+const GRPC_TO_HTTP: Record<number, number> = {
+  [Code.InvalidArgument]: 400,
+  [Code.FailedPrecondition]: 400,
+  [Code.OutOfRange]: 400,
+  [Code.Unauthenticated]: 401,
+  [Code.PermissionDenied]: 403,
+  [Code.NotFound]: 404,
+  [Code.AlreadyExists]: 409,
+  [Code.Aborted]: 409,
+  [Code.ResourceExhausted]: 429,
+  [Code.Canceled]: 499,
+  [Code.DataLoss]: 500,
+  [Code.Unknown]: 500,
+  [Code.Internal]: 500,
+  [Code.Unimplemented]: 501,
+  [Code.Unavailable]: 503,
+  [Code.DeadlineExceeded]: 504,
+};
+
+// HTTP to gRPC status mapping
+const HTTP_TO_GRPC: Record<number, number> = {
+  200: Code.Unknown, // No direct mapping for 200
+  400: Code.InvalidArgument,
+  401: Code.Unauthenticated,
+  403: Code.PermissionDenied,
+  404: Code.NotFound,
+  409: Code.AlreadyExists,
+  429: Code.ResourceExhausted,
+  500: Code.Internal,
+  501: Code.Unimplemented,
+  503: Code.Unavailable,
+  504: Code.DeadlineExceeded,
+};
+
+// HTTP status constants
+const HTTP_STATUS = {
+  'OK': 200,
+  'BAD_REQUEST': 400,
+  'UNAUTHORIZED': 401,
+  'FORBIDDEN': 403,
+  'NOT_FOUND': 404,
+  'CONFLICT': 409,
+  'TOO_MANY_REQUESTS': 429,
+  'INTERNAL_SERVER_ERROR': 500,
+  'NOT_IMPLEMENTED': 501,
+  'SERVICE_UNAVAILABLE': 503,
+  'GATEWAY_TIMEOUT': 504,
+};
+
+// Base exception class
+export class ScalekitException extends Error {
+  constructor(error: any) {
+    super(error?.message || error?.toString() || 'Unknown error');
+    this.name = 'ScalekitException';
+  }
+}
+
+// Webhook verification error
+export class WebhookVerificationError extends ScalekitException {
+  constructor(error: any) {
+    super(error);
+    this.name = 'WebhookVerificationError';
+  }
+}
+
+// Token validation failure exception
+export class ScalekitValidateTokenFailureException extends ScalekitException {
+  constructor(error: any) {
+    super(error);
+    this.name = 'ScalekitValidateTokenFailureException';
   }
 }
 
 // Base server exception
-export class ScalekitServerException extends ConnectError {
+export class ScalekitServerException extends ScalekitException {
   private _grpcStatus: Code;
   private _httpStatus: number;
-  private _message: string;
-  private _errDetails: any[];
+  private _message: string | null;
+  private _errDetails: any;
   private _errorCode: string | null;
   private _unpackedDetails: ErrorInfo[];
 
-  constructor(exception: ConnectError) {
-    super(exception.message, exception.code);
+  constructor(error: AxiosResponse | ConnectError) {
+    super(error);
     
-    this._grpcStatus = exception.code;
-    this._httpStatus = GRPC_TO_HTTP_STATUS[exception.code] || 500;
-    this._message = exception.message;
-    this._errDetails = exception.findDetails(ErrorInfo);
-    this._errorCode = null;
     this._unpackedDetails = [];
+    
+    if (this.isAxiosResponse(error)) {
+      // Handle HTTP Response errors
+      if (error.statusText && typeof error.statusText === 'string') {
+        this._httpStatus = HTTP_STATUS[error.statusText.toUpperCase() as keyof typeof HTTP_STATUS] || HTTP_STATUS.INTERNAL_SERVER_ERROR;
+      } else {
+        this._httpStatus = HTTP_STATUS.INTERNAL_SERVER_ERROR;
+      }
+      this._grpcStatus = HTTP_TO_GRPC[error.status] || Code.Unknown;
+      this._errorCode = error.statusText;
+      this._errDetails = error.data;
+      this._message = null;
+    } else {
+      // Handle gRPC ConnectError
+      this._grpcStatus = error.code;
+      this._httpStatus = GRPC_TO_HTTP[error.code] || 500;
+      this._message = error.message;
+      this._errDetails = error.findDetails(ErrorInfo);
+      this._errorCode = null;
 
-    // Unpack error details
-    for (const detail of this._errDetails) {
-      this._unpackedDetails.push(detail);
-      if (!this._errorCode) {
-        this._errorCode = detail.errorCode;
+      // Unpack error details
+      for (const detail of this._errDetails) {
+        this._unpackedDetails.push(detail);
+        if (!this._errorCode) {
+          this._errorCode = detail.errorCode;
+        }
       }
     }
 
     this.name = 'ScalekitServerException';
   }
 
+  private isAxiosResponse(error: any): error is AxiosResponse {
+    return error && typeof error.status === 'number' && typeof error.statusText === 'string';
+  }
+
   // String representation
   toString(): string {
-    const border = '='.repeat(40);
-    let detailsStr = JSON.stringify(this._unpackedDetails, null, 2);
+    const border = '========================================';
     
-    return `\n${border}\n` +
-           `Error Code: ${this._errorCode}\n` +
-           `GRPC: (${this._grpcStatus}: ${this._grpcStatus})\n` +
-           `HTTP: (${this._httpStatus})\n` +
-           `Error Details:\n` +
-           `${this._message}: ${detailsStr}\n${border}\n`;
+    if (this._unpackedDetails.length > 0) {
+      let detailsStr = JSON.stringify(this._unpackedDetails, null, 2);
+      if (detailsStr.startsWith("[") && detailsStr.includes("\n")) {
+        detailsStr = detailsStr.replace("[", "[\n");
+      }
+      return `\n${border}\n` +
+             `Error Code: ${this._errorCode}\n` +
+             `GRPC: (${this._grpcStatus}: ${this._grpcStatus})\n` +
+             `HTTP: (${this._httpStatus})\n` +
+             `Error Details:\n` +
+             `${this._message}: ${detailsStr}\n${border}\n`;
+    } else {
+      return `\n${border}\n` +
+             `Error Code: ${this._errorCode}\n` +
+             `GRPC: (${this._grpcStatus}: ${this._grpcStatus})\n` +
+             `HTTP: (${this._httpStatus})\n` +
+             `Error Details: ${this._errDetails}\n${border}\n`;
+    }
   }
 
   // Getters
@@ -67,10 +163,10 @@ export class ScalekitServerException extends ConnectError {
   }
 
   get message(): string {
-    return this._message;
+    return this._message || super.message;
   }
 
-  get errDetails(): any[] {
+  get errDetails(): any {
     return this._errDetails;
   }
 

--- a/src/errors/base-exception.ts
+++ b/src/errors/base-exception.ts
@@ -1,0 +1,80 @@
+import { ConnectError, Code } from '@connectrpc/connect';
+import { ErrorInfo } from '../pkg/grpc/scalekit/v1/errdetails/errdetails_pb';
+import { GRPC_TO_HTTP_STATUS } from './grpc-codes';
+
+// Base client exception
+export class ScalekitClientException extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ScalekitClientException';
+  }
+}
+
+// Base server exception
+export class ScalekitServerException extends ConnectError {
+  private _grpcStatus: Code;
+  private _httpStatus: number;
+  private _message: string;
+  private _errDetails: any[];
+  private _errorCode: string | null;
+  private _unpackedDetails: ErrorInfo[];
+
+  constructor(exception: ConnectError) {
+    super(exception.message, exception.code);
+    
+    this._grpcStatus = exception.code;
+    this._httpStatus = GRPC_TO_HTTP_STATUS[exception.code] || 500;
+    this._message = exception.message;
+    this._errDetails = exception.findDetails(ErrorInfo);
+    this._errorCode = null;
+    this._unpackedDetails = [];
+
+    // Unpack error details
+    for (const detail of this._errDetails) {
+      this._unpackedDetails.push(detail);
+      if (!this._errorCode) {
+        this._errorCode = detail.errorCode;
+      }
+    }
+
+    this.name = 'ScalekitServerException';
+  }
+
+  // String representation
+  toString(): string {
+    const border = '='.repeat(40);
+    let detailsStr = JSON.stringify(this._unpackedDetails, null, 2);
+    
+    return `\n${border}\n` +
+           `Error Code: ${this._errorCode}\n` +
+           `GRPC: (${this._grpcStatus}: ${this._grpcStatus})\n` +
+           `HTTP: (${this._httpStatus})\n` +
+           `Error Details:\n` +
+           `${this._message}: ${detailsStr}\n${border}\n`;
+  }
+
+  // Getters
+  get grpcStatus(): Code {
+    return this._grpcStatus;
+  }
+
+  get httpStatus(): number {
+    return this._httpStatus;
+  }
+
+  get errorCode(): string | null {
+    return this._errorCode;
+  }
+
+  get message(): string {
+    return this._message;
+  }
+
+  get errDetails(): any[] {
+    return this._errDetails;
+  }
+
+  get unpackedDetails(): ErrorInfo[] {
+    return this._unpackedDetails;
+  }
+} 

--- a/src/errors/error-transformer.ts
+++ b/src/errors/error-transformer.ts
@@ -1,0 +1,34 @@
+import { ConnectError } from '@connectrpc/connect';
+import { AxiosError } from 'axios';
+import { ScalekitClientException, ScalekitServerException } from './base-exception';
+import { scalekitException } from './exception-factory';
+
+/**
+ * Transforms various error types into Scalekit-specific exceptions
+ * @param error - The original error to transform
+ * @returns A ScalekitException instance
+ */
+export function transformError(error: any): ScalekitServerException | ScalekitClientException {
+  // Handle gRPC Connect errors
+  if (error instanceof ConnectError) {
+    return scalekitException(error);
+  }
+  
+  // Handle HTTP/Axios errors
+  if (error instanceof AxiosError) {
+    const status = error.response?.status || 0;
+    const message = error.response?.data?.message || error.message;
+    
+    // Create a mock ConnectError for HTTP errors to use the same exception hierarchy
+    const mockConnectError = new ConnectError(message, status);
+    return scalekitException(mockConnectError);
+  }
+  
+  // Handle existing ScalekitException instances
+  if (error instanceof ScalekitServerException || error instanceof ScalekitClientException) {
+    return error;
+  }
+  
+  // Handle generic errors
+  return new ScalekitClientException(error.message || 'Unknown error occurred');
+} 

--- a/src/errors/exception-factory.ts
+++ b/src/errors/exception-factory.ts
@@ -1,0 +1,62 @@
+import { ConnectError, Code } from '@connectrpc/connect';
+import { ScalekitServerException } from './base-exception';
+import {
+  ScalekitInvalidArgumentException,
+  ScalekitFailedPreconditionException,
+  ScalekitOutOfRangeException,
+  ScalekitUnauthenticatedException,
+  ScalekitPermissionDeniedException,
+  ScalekitNotFoundException,
+  ScalekitConflictException,
+  ScalekitResourceExhaustedException,
+  ScalekitCancelledException,
+  ScalekitDataLossException,
+  ScalekitUnknownException,
+  ScalekitInternalServerException,
+  ScalekitUnimplementedException,
+  ScalekitServiceUnavailableException,
+  ScalekitDeadlineExceededException,
+} from './specific-exceptions';
+
+/**
+ * Factory function to create specific Scalekit exceptions from gRPC errors
+ */
+export function scalekitException(grpcError: ConnectError): ScalekitServerException {
+  const grpcStatus = grpcError.code;
+
+  switch (grpcStatus) {
+    case Code.InvalidArgument:
+      return new ScalekitInvalidArgumentException(grpcError);
+    case Code.FailedPrecondition:
+      return new ScalekitFailedPreconditionException(grpcError);
+    case Code.OutOfRange:
+      return new ScalekitOutOfRangeException(grpcError);
+    case Code.Unauthenticated:
+      return new ScalekitUnauthenticatedException(grpcError);
+    case Code.PermissionDenied:
+      return new ScalekitPermissionDeniedException(grpcError);
+    case Code.NotFound:
+      return new ScalekitNotFoundException(grpcError);
+    case Code.AlreadyExists:
+    case Code.Aborted:
+      return new ScalekitConflictException(grpcError);
+    case Code.ResourceExhausted:
+      return new ScalekitResourceExhaustedException(grpcError);
+    case Code.Canceled:
+      return new ScalekitCancelledException(grpcError);
+    case Code.DataLoss:
+      return new ScalekitDataLossException(grpcError);
+    case Code.Unknown:
+      return new ScalekitUnknownException(grpcError);
+    case Code.Internal:
+      return new ScalekitInternalServerException(grpcError);
+    case Code.Unimplemented:
+      return new ScalekitUnimplementedException(grpcError);
+    case Code.Unavailable:
+      return new ScalekitServiceUnavailableException(grpcError);
+    case Code.DeadlineExceeded:
+      return new ScalekitDeadlineExceededException(grpcError);
+    default:
+      return new ScalekitUnknownException(grpcError);
+  }
+} 

--- a/src/errors/grpc-codes.ts
+++ b/src/errors/grpc-codes.ts
@@ -1,0 +1,44 @@
+import { Code } from '@connectrpc/connect';
+
+// gRPC code names for reverse lookup
+export const GRPC_CODE_NAMES: Record<number, string> = {
+  [Code.InvalidArgument]: 'INVALID_ARGUMENT',
+  [Code.Unauthenticated]: 'UNAUTHENTICATED',
+  [Code.PermissionDenied]: 'PERMISSION_DENIED',
+  [Code.NotFound]: 'NOT_FOUND',
+  [Code.AlreadyExists]: 'ALREADY_EXISTS',
+  [Code.ResourceExhausted]: 'RESOURCE_EXHAUSTED',
+  [Code.Unavailable]: 'UNAVAILABLE',
+  [Code.DeadlineExceeded]: 'DEADLINE_EXCEEDED',
+  [Code.Unknown]: 'UNKNOWN',
+};
+
+// Mapping from gRPC codes to HTTP status codes
+export const GRPC_TO_HTTP_STATUS: Record<number, number> = {
+  [Code.InvalidArgument]: 400,
+  [Code.Unauthenticated]: 401,
+  [Code.PermissionDenied]: 403,
+  [Code.NotFound]: 404,
+  [Code.AlreadyExists]: 409,
+  [Code.ResourceExhausted]: 429,
+  [Code.Unavailable]: 503,
+  [Code.DeadlineExceeded]: 408,
+  [Code.Unknown]: 500,
+};
+
+// Helper function to get gRPC code name
+export function getGrpcCodeName(code: number): string {
+  return GRPC_CODE_NAMES[code] || 'UNKNOWN';
+}
+
+// Helper function to get HTTP status from gRPC code
+export function getHttpStatusFromGrpcCode(grpcCode: number): number {
+  return GRPC_TO_HTTP_STATUS[grpcCode] || 500;
+}
+
+// Helper function to get gRPC code from HTTP status
+export function getGrpcCodeFromHttpStatus(httpStatus: number): number {
+  const entries = Object.entries(GRPC_TO_HTTP_STATUS);
+  const entry = entries.find(([_, status]) => status === httpStatus);
+  return entry ? parseInt(entry[0]) : Code.Unknown;
+} 

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,10 @@
+// Export base exceptions
+export * from './base-exception';
+export * from './specific-exceptions';
+export * from './exception-factory';
+
+// Export the transformation function
+export { transformError } from './error-transformer';
+
+// Export gRPC utilities
+export * from './grpc-codes'; 

--- a/src/errors/specific-exceptions.ts
+++ b/src/errors/specific-exceptions.ts
@@ -1,108 +1,88 @@
 import { ConnectError } from '@connectrpc/connect';
+import { AxiosResponse } from 'axios';
 import { ScalekitServerException } from './base-exception';
 
-// Specific exception classes
-export class ScalekitInvalidArgumentException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
-    this.name = 'ScalekitInvalidArgumentException';
+// Specific exception classes with new naming (matching Python SDK)
+export class ScalekitBadRequestException extends ScalekitServerException {
+  constructor(error: AxiosResponse | ConnectError) {
+    super(error);
+    this.name = 'ScalekitBadRequestException';
   }
 }
 
-export class ScalekitFailedPreconditionException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
-    this.name = 'ScalekitFailedPreconditionException';
+export class ScalekitUnauthorizedException extends ScalekitServerException {
+  constructor(error: AxiosResponse | ConnectError) {
+    super(error);
+    this.name = 'ScalekitUnauthorizedException';
+  }
+}
+
+export class ScalekitForbiddenException extends ScalekitServerException {
+  constructor(error: AxiosResponse | ConnectError) {
+    super(error);
+    this.name = 'ScalekitForbiddenException';
   }
 }
 
 export class ScalekitNotFoundException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
+  constructor(error: AxiosResponse | ConnectError) {
+    super(error);
     this.name = 'ScalekitNotFoundException';
   }
 }
 
-export class ScalekitUnauthenticatedException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
-    this.name = 'ScalekitUnauthenticatedException';
-  }
-}
-
-export class ScalekitPermissionDeniedException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
-    this.name = 'ScalekitPermissionDeniedException';
-  }
-}
-
-export class ScalekitInternalServerException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
-    this.name = 'ScalekitInternalServerException';
-  }
-}
-
-export class ScalekitServiceUnavailableException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
-    this.name = 'ScalekitServiceUnavailableException';
-  }
-}
-
 export class ScalekitConflictException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
+  constructor(error: AxiosResponse | ConnectError) {
+    super(error);
     this.name = 'ScalekitConflictException';
   }
 }
 
-export class ScalekitResourceExhaustedException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
-    this.name = 'ScalekitResourceExhaustedException';
+export class ScalekitTooManyRequestsException extends ScalekitServerException {
+  constructor(error: AxiosResponse | ConnectError) {
+    super(error);
+    this.name = 'ScalekitTooManyRequestsException';
   }
 }
 
-export class ScalekitUnknownException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
-    this.name = 'ScalekitUnknownException';
+export class ScalekitInternalServerException extends ScalekitServerException {
+  constructor(error: AxiosResponse | ConnectError) {
+    super(error);
+    this.name = 'ScalekitInternalServerException';
   }
 }
 
-export class ScalekitUnimplementedException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
-    this.name = 'ScalekitUnimplementedException';
+export class ScalekitNotImplementedException extends ScalekitServerException {
+  constructor(error: AxiosResponse | ConnectError) {
+    super(error);
+    this.name = 'ScalekitNotImplementedException';
   }
 }
 
-export class ScalekitDeadlineExceededException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
-    this.name = 'ScalekitDeadlineExceededException';
+export class ScalekitServiceUnavailableException extends ScalekitServerException {
+  constructor(error: AxiosResponse | ConnectError) {
+    super(error);
+    this.name = 'ScalekitServiceUnavailableException';
   }
 }
 
-export class ScalekitDataLossException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
-    this.name = 'ScalekitDataLossException';
-  }
-}
-
-export class ScalekitOutOfRangeException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
-    this.name = 'ScalekitOutOfRangeException';
+export class ScalekitGatewayTimeoutException extends ScalekitServerException {
+  constructor(error: AxiosResponse | ConnectError) {
+    super(error);
+    this.name = 'ScalekitGatewayTimeoutException';
   }
 }
 
 export class ScalekitCancelledException extends ScalekitServerException {
-  constructor(exception: ConnectError) {
-    super(exception);
+  constructor(error: AxiosResponse | ConnectError) {
+    super(error);
     this.name = 'ScalekitCancelledException';
+  }
+}
+
+export class ScalekitUnknownException extends ScalekitServerException {
+  constructor(error: AxiosResponse | ConnectError) {
+    super(error);
+    this.name = 'ScalekitUnknownException';
   }
 } 

--- a/src/errors/specific-exceptions.ts
+++ b/src/errors/specific-exceptions.ts
@@ -1,0 +1,108 @@
+import { ConnectError } from '@connectrpc/connect';
+import { ScalekitServerException } from './base-exception';
+
+// Specific exception classes
+export class ScalekitInvalidArgumentException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitInvalidArgumentException';
+  }
+}
+
+export class ScalekitFailedPreconditionException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitFailedPreconditionException';
+  }
+}
+
+export class ScalekitNotFoundException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitNotFoundException';
+  }
+}
+
+export class ScalekitUnauthenticatedException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitUnauthenticatedException';
+  }
+}
+
+export class ScalekitPermissionDeniedException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitPermissionDeniedException';
+  }
+}
+
+export class ScalekitInternalServerException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitInternalServerException';
+  }
+}
+
+export class ScalekitServiceUnavailableException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitServiceUnavailableException';
+  }
+}
+
+export class ScalekitConflictException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitConflictException';
+  }
+}
+
+export class ScalekitResourceExhaustedException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitResourceExhaustedException';
+  }
+}
+
+export class ScalekitUnknownException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitUnknownException';
+  }
+}
+
+export class ScalekitUnimplementedException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitUnimplementedException';
+  }
+}
+
+export class ScalekitDeadlineExceededException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitDeadlineExceededException';
+  }
+}
+
+export class ScalekitDataLossException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitDataLossException';
+  }
+}
+
+export class ScalekitOutOfRangeException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitOutOfRangeException';
+  }
+}
+
+export class ScalekitCancelledException extends ScalekitServerException {
+  constructor(exception: ConnectError) {
+    super(exception);
+    this.name = 'ScalekitCancelledException';
+  }
+} 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,5 @@ export default ScalekitClient;
 
 export * from "./types/scalekit";
 export * from "./types/auth";
+
+export * from "./errors";


### PR DESCRIPTION
This PR implements comprehensive error handling updates for the Node.js SDK methods. Compared to the earlier version where we used to raise only basic error messages as part of the exceptions, here we are providing customers with a rich error response that contains gRPC error codes, HTTP error codes, and detailed error information.

 **Error Response Structure**
The Error returned by this change provides the following enhanced information:
Example 1:
ScalekitServerException - Inheriting ScalekitException
grpcStatus (Code.INVALID_ARGUMENT: 3)
httpStatus (400)
errDetails (['Validation error', 'user.email: value must be a valid email address'])
errorCode ('INVALID_ARGUMENT')
message ('Validation error')

**Error Display Example**

ScalekitBadRequestException: 
========================================
Error Code: INVALID_ARGUMENT
GRPC: (INVALID_ARGUMENT: 3)
HTTP: (400)
Error Details:
Validation error: [
  {
    "errorCode": "INVALID_ARGUMENT",
    "validationErrorInfo": {
      "fieldViolations": [
        {
          "field": "user.email",
          "description": "value must be a valid email address",
          "constraint": "string.email"
        }
      ]
    }
  }
]
========================================
