### PR TITLE
Rename sendActivationEmail to sendInvitationEmail and add resendInvite sdk method

### DIFF
--- a/src/pkg/grpc/scalekit/v1/commons/commons_pb.ts
+++ b/src/pkg/grpc/scalekit/v1/commons/commons_pb.ts
@@ -36,13 +36,13 @@ proto3.util.setEnumType(RegionCode, "scalekit.v1.commons.RegionCode", [
 ]);
 
 /**
- * @generated from enum scalekit.v1.commons.UserStatus
+ * @generated from enum scalekit.v1.commons.MembershipStatus
  */
-export enum UserStatus {
+export enum MembershipStatus {
   /**
-   * @generated from enum value: USER_STATUS_UNSPECIFIED = 0;
+   * @generated from enum value: Membership_Status_UNSPECIFIED = 0;
    */
-  USER_STATUS_UNSPECIFIED = 0,
+  Membership_Status_UNSPECIFIED = 0,
 
   /**
    * @generated from enum value: ACTIVE = 1;
@@ -55,132 +55,22 @@ export enum UserStatus {
   INACTIVE = 2,
 
   /**
-   * @generated from enum value: INVITED = 3;
+   * @generated from enum value: PENDING_INVITE = 3;
    */
-  INVITED = 3,
+  PENDING_INVITE = 3,
 
   /**
-   * @generated from enum value: PENDING = 4;
+   * @generated from enum value: INVITE_EXPIRED = 4;
    */
-  PENDING = 4,
+  INVITE_EXPIRED = 4,
 }
-// Retrieve enum metadata with: proto3.getEnumType(UserStatus)
-proto3.util.setEnumType(UserStatus, "scalekit.v1.commons.UserStatus", [
-  { no: 0, name: "USER_STATUS_UNSPECIFIED" },
+// Retrieve enum metadata with: proto3.getEnumType(MembershipStatus)
+proto3.util.setEnumType(MembershipStatus, "scalekit.v1.commons.MembershipStatus", [
+  { no: 0, name: "Membership_Status_UNSPECIFIED" },
   { no: 1, name: "ACTIVE" },
   { no: 2, name: "INACTIVE" },
-  { no: 3, name: "INVITED" },
-  { no: 4, name: "PENDING" },
-]);
-
-/**
- * @generated from enum scalekit.v1.commons.IdentityProviderType
- */
-export enum IdentityProviderType {
-  /**
-   * @generated from enum value: IDENTITY_PROVIDER_UNSPECIFIED = 0;
-   */
-  IDENTITY_PROVIDER_UNSPECIFIED = 0,
-
-  /**
-   * @generated from enum value: OKTA = 1;
-   */
-  OKTA = 1,
-
-  /**
-   * @generated from enum value: GOOGLE = 2;
-   */
-  GOOGLE = 2,
-
-  /**
-   * @generated from enum value: MICROSOFT_AD = 3;
-   */
-  MICROSOFT_AD = 3,
-
-  /**
-   * @generated from enum value: AUTH0 = 4;
-   */
-  AUTH0 = 4,
-
-  /**
-   * @generated from enum value: ONELOGIN = 5;
-   */
-  ONELOGIN = 5,
-
-  /**
-   * @generated from enum value: PING_IDENTITY = 6;
-   */
-  PING_IDENTITY = 6,
-
-  /**
-   * @generated from enum value: JUMPCLOUD = 7;
-   */
-  JUMPCLOUD = 7,
-
-  /**
-   * @generated from enum value: CUSTOM = 8;
-   */
-  CUSTOM = 8,
-
-  /**
-   * @generated from enum value: GITHUB = 9;
-   */
-  GITHUB = 9,
-
-  /**
-   * @generated from enum value: GITLAB = 10;
-   */
-  GITLAB = 10,
-
-  /**
-   * @generated from enum value: LINKEDIN = 11;
-   */
-  LINKEDIN = 11,
-
-  /**
-   * @generated from enum value: SALESFORCE = 12;
-   */
-  SALESFORCE = 12,
-
-  /**
-   * @generated from enum value: MICROSOFT = 13;
-   */
-  MICROSOFT = 13,
-
-  /**
-   * @generated from enum value: IDP_SIMULATOR = 14;
-   */
-  IDP_SIMULATOR = 14,
-
-  /**
-   * @generated from enum value: SCALEKIT = 15;
-   */
-  SCALEKIT = 15,
-
-  /**
-   * @generated from enum value: ADFS = 16;
-   */
-  ADFS = 16,
-}
-// Retrieve enum metadata with: proto3.getEnumType(IdentityProviderType)
-proto3.util.setEnumType(IdentityProviderType, "scalekit.v1.commons.IdentityProviderType", [
-  { no: 0, name: "IDENTITY_PROVIDER_UNSPECIFIED" },
-  { no: 1, name: "OKTA" },
-  { no: 2, name: "GOOGLE" },
-  { no: 3, name: "MICROSOFT_AD" },
-  { no: 4, name: "AUTH0" },
-  { no: 5, name: "ONELOGIN" },
-  { no: 6, name: "PING_IDENTITY" },
-  { no: 7, name: "JUMPCLOUD" },
-  { no: 8, name: "CUSTOM" },
-  { no: 9, name: "GITHUB" },
-  { no: 10, name: "GITLAB" },
-  { no: 11, name: "LINKEDIN" },
-  { no: 12, name: "SALESFORCE" },
-  { no: 13, name: "MICROSOFT" },
-  { no: 14, name: "IDP_SIMULATOR" },
-  { no: 15, name: "SCALEKIT" },
-  { no: 16, name: "ADFS" },
+  { no: 3, name: "PENDING_INVITE" },
+  { no: 4, name: "INVITE_EXPIRED" },
 ]);
 
 /**
@@ -198,9 +88,9 @@ export class OrganizationMembership extends Message<OrganizationMembership> {
   joinTime?: Timestamp;
 
   /**
-   * @generated from field: scalekit.v1.commons.UserStatus membership_status = 3;
+   * @generated from field: scalekit.v1.commons.MembershipStatus membership_status = 3;
    */
-  membershipStatus = UserStatus.USER_STATUS_UNSPECIFIED;
+  membershipStatus = MembershipStatus.Membership_Status_UNSPECIFIED;
 
   /**
    * @generated from field: repeated scalekit.v1.commons.Role roles = 4;
@@ -213,14 +103,34 @@ export class OrganizationMembership extends Message<OrganizationMembership> {
   name?: string;
 
   /**
-   * @generated from field: scalekit.v1.commons.IdentityProviderType primary_identity_provider = 6;
-   */
-  primaryIdentityProvider = IdentityProviderType.IDENTITY_PROVIDER_UNSPECIFIED;
-
-  /**
    * @generated from field: map<string, string> metadata = 7;
    */
   metadata: { [key: string]: string } = {};
+
+  /**
+   * @generated from field: optional string display_name = 9;
+   */
+  displayName?: string;
+
+  /**
+   * @generated from field: optional string invited_by = 10;
+   */
+  invitedBy?: string;
+
+  /**
+   * @generated from field: optional google.protobuf.Timestamp created_at = 11;
+   */
+  createdAt?: Timestamp;
+
+  /**
+   * @generated from field: optional google.protobuf.Timestamp accepted_at = 12;
+   */
+  acceptedAt?: Timestamp;
+
+  /**
+   * @generated from field: optional google.protobuf.Timestamp expires_at = 13;
+   */
+  expiresAt?: Timestamp;
 
   constructor(data?: PartialMessage<OrganizationMembership>) {
     super();
@@ -232,11 +142,15 @@ export class OrganizationMembership extends Message<OrganizationMembership> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "join_time", kind: "message", T: Timestamp },
-    { no: 3, name: "membership_status", kind: "enum", T: proto3.getEnumType(UserStatus) },
+    { no: 3, name: "membership_status", kind: "enum", T: proto3.getEnumType(MembershipStatus) },
     { no: 4, name: "roles", kind: "message", T: Role, repeated: true },
     { no: 5, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
-    { no: 6, name: "primary_identity_provider", kind: "enum", T: proto3.getEnumType(IdentityProviderType) },
     { no: 7, name: "metadata", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "scalar", T: 9 /* ScalarType.STRING */} },
+    { no: 9, name: "display_name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 10, name: "invited_by", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 11, name: "created_at", kind: "message", T: Timestamp, opt: true },
+    { no: 12, name: "accepted_at", kind: "message", T: Timestamp, opt: true },
+    { no: 13, name: "expires_at", kind: "message", T: Timestamp, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): OrganizationMembership {
@@ -270,6 +184,11 @@ export class Role extends Message<Role> {
    */
   name = "";
 
+  /**
+   * @generated from field: string display_name = 3;
+   */
+  displayName = "";
+
   constructor(data?: PartialMessage<Role>) {
     super();
     proto3.util.initPartial(data, this);
@@ -280,6 +199,7 @@ export class Role extends Message<Role> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "display_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Role {

--- a/src/pkg/grpc/scalekit/v1/connections/connections_connect.ts
+++ b/src/pkg/grpc/scalekit/v1/connections/connections_connect.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { CreateConnectionRequest, CreateConnectionResponse, CreateEnvironmentConnectionRequest, DeleteConnectionRequest, DeleteEnvironmentConnectionRequest, GetConnectionRequest, GetConnectionResponse, GetConnectionTestResultRequest, GetConnectionTestResultResponse, GetEnvironmentConnectionRequest, GetProvidersRequest, GetProvidersResponse, ListConnectionsRequest, ListConnectionsResponse, ListOrganizationConnectionsRequest, ListOrganizationConnectionsResponse, SearchOrganizationConnectionsRequest, SearchOrganizationConnectionsResponse, ToggleConnectionRequest, ToggleConnectionResponse, ToggleEnvironmentConnectionRequest, UpdateConnectionRequest, UpdateConnectionResponse, UpdateEnvironmentConnectionRequest } from "./connections_pb.js";
+import { AssignDomainsToConnectionRequest, AssignDomainsToConnectionResponse, CreateConnectionRequest, CreateConnectionResponse, CreateEnvironmentConnectionRequest, DeleteConnectionRequest, DeleteEnvironmentConnectionRequest, GetConnectionRequest, GetConnectionResponse, GetConnectionTestResultRequest, GetConnectionTestResultResponse, GetEnvironmentConnectionRequest, ListAppConnectionsRequest, ListAppConnectionsResponse, ListConnectionsRequest, ListConnectionsResponse, ListOrganizationConnectionsRequest, ListOrganizationConnectionsResponse, SearchOrganizationConnectionsRequest, SearchOrganizationConnectionsResponse, ToggleConnectionRequest, ToggleConnectionResponse, ToggleEnvironmentConnectionRequest, UpdateConnectionRequest, UpdateConnectionResponse, UpdateEnvironmentConnectionRequest } from "./connections_pb.js";
 import { Empty, MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -12,15 +12,6 @@ import { Empty, MethodKind } from "@bufbuild/protobuf";
 export const ConnectionService = {
   typeName: "scalekit.v1.connections.ConnectionService",
   methods: {
-    /**
-     * @generated from rpc scalekit.v1.connections.ConnectionService.GetProviders
-     */
-    getProviders: {
-      name: "GetProviders",
-      I: GetProvidersRequest,
-      O: GetProvidersResponse,
-      kind: MethodKind.Unary,
-    },
     /**
      * @generated from rpc scalekit.v1.connections.ConnectionService.CreateEnvironmentConnection
      */
@@ -37,6 +28,15 @@ export const ConnectionService = {
       name: "CreateConnection",
       I: CreateConnectionRequest,
       O: CreateConnectionResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * @generated from rpc scalekit.v1.connections.ConnectionService.AssignDomainsToConnection
+     */
+    assignDomainsToConnection: {
+      name: "AssignDomainsToConnection",
+      I: AssignDomainsToConnectionRequest,
+      O: AssignDomainsToConnectionResponse,
       kind: MethodKind.Unary,
     },
     /**
@@ -163,6 +163,15 @@ export const ConnectionService = {
       name: "GetConnectionTestResult",
       I: GetConnectionTestResultRequest,
       O: GetConnectionTestResultResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * @generated from rpc scalekit.v1.connections.ConnectionService.ListAppConnections
+     */
+    listAppConnections: {
+      name: "ListAppConnections",
+      I: ListAppConnectionsRequest,
+      O: ListAppConnectionsResponse,
       kind: MethodKind.Unary,
     },
   }

--- a/src/pkg/grpc/scalekit/v1/connections/connections_pb.ts
+++ b/src/pkg/grpc/scalekit/v1/connections/connections_pb.ts
@@ -4,7 +4,8 @@
 // @ts-nocheck
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { BoolValue, Message, proto3, protoInt64, StringValue, Timestamp, UInt32Value } from "@bufbuild/protobuf";
+import { BoolValue, Message, proto3, protoInt64, StringValue, Struct, Timestamp, UInt32Value } from "@bufbuild/protobuf";
+import { Domain } from "../domains/domains_pb.js";
 
 /**
  * @generated from enum scalekit.v1.connections.CodeChallengeType
@@ -329,6 +330,21 @@ export enum ConnectionType {
    * @generated from enum value: PASSWORDLESS = 5;
    */
   PASSWORDLESS = 5,
+
+  /**
+   * @generated from enum value: BASIC = 6;
+   */
+  BASIC = 6,
+
+  /**
+   * @generated from enum value: BEARER = 7;
+   */
+  BEARER = 7,
+
+  /**
+   * @generated from enum value: API_KEY = 8;
+   */
+  API_KEY = 8,
 }
 // Retrieve enum metadata with: proto3.getEnumType(ConnectionType)
 proto3.util.setEnumType(ConnectionType, "scalekit.v1.connections.ConnectionType", [
@@ -338,6 +354,9 @@ proto3.util.setEnumType(ConnectionType, "scalekit.v1.connections.ConnectionType"
   { no: 3, name: "PASSWORD" },
   { no: 4, name: "OAUTH" },
   { no: 5, name: "PASSWORDLESS" },
+  { no: 6, name: "BASIC" },
+  { no: 7, name: "BEARER" },
+  { no: 8, name: "API_KEY" },
 ]);
 
 /**
@@ -483,6 +502,92 @@ proto3.util.setEnumType(ConnectionProvider, "scalekit.v1.connections.ConnectionP
 ]);
 
 /**
+ * @generated from message scalekit.v1.connections.AssignDomainsToConnectionRequest
+ */
+export class AssignDomainsToConnectionRequest extends Message<AssignDomainsToConnectionRequest> {
+  /**
+   * @generated from field: string organization_id = 1;
+   */
+  organizationId = "";
+
+  /**
+   * @generated from field: string connection_id = 2;
+   */
+  connectionId = "";
+
+  /**
+   * @generated from field: repeated string domain_ids = 3;
+   */
+  domainIds: string[] = [];
+
+  constructor(data?: PartialMessage<AssignDomainsToConnectionRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.connections.AssignDomainsToConnectionRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "connection_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "domain_ids", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AssignDomainsToConnectionRequest {
+    return new AssignDomainsToConnectionRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): AssignDomainsToConnectionRequest {
+    return new AssignDomainsToConnectionRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): AssignDomainsToConnectionRequest {
+    return new AssignDomainsToConnectionRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: AssignDomainsToConnectionRequest | PlainMessage<AssignDomainsToConnectionRequest> | undefined, b: AssignDomainsToConnectionRequest | PlainMessage<AssignDomainsToConnectionRequest> | undefined): boolean {
+    return proto3.util.equals(AssignDomainsToConnectionRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.connections.AssignDomainsToConnectionResponse
+ */
+export class AssignDomainsToConnectionResponse extends Message<AssignDomainsToConnectionResponse> {
+  /**
+   * @generated from field: scalekit.v1.connections.Connection connection = 1;
+   */
+  connection?: Connection;
+
+  constructor(data?: PartialMessage<AssignDomainsToConnectionResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.connections.AssignDomainsToConnectionResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "connection", kind: "message", T: Connection },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AssignDomainsToConnectionResponse {
+    return new AssignDomainsToConnectionResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): AssignDomainsToConnectionResponse {
+    return new AssignDomainsToConnectionResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): AssignDomainsToConnectionResponse {
+    return new AssignDomainsToConnectionResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: AssignDomainsToConnectionResponse | PlainMessage<AssignDomainsToConnectionResponse> | undefined, b: AssignDomainsToConnectionResponse | PlainMessage<AssignDomainsToConnectionResponse> | undefined): boolean {
+    return proto3.util.equals(AssignDomainsToConnectionResponse, a, b);
+  }
+}
+
+/**
  * @generated from message scalekit.v1.connections.GetProvidersRequest
  */
 export class GetProvidersRequest extends Message<GetProvidersRequest> {
@@ -608,6 +713,11 @@ export class CreateEnvironmentConnectionRequest extends Message<CreateEnvironmen
    */
   connection?: CreateConnection;
 
+  /**
+   * @generated from field: optional scalekit.v1.connections.Flags flags = 2;
+   */
+  flags?: Flags;
+
   constructor(data?: PartialMessage<CreateEnvironmentConnectionRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -617,6 +727,7 @@ export class CreateEnvironmentConnectionRequest extends Message<CreateEnvironmen
   static readonly typeName = "scalekit.v1.connections.CreateEnvironmentConnectionRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "connection", kind: "message", T: CreateConnection },
+    { no: 2, name: "flags", kind: "message", T: Flags, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateEnvironmentConnectionRequest {
@@ -693,6 +804,16 @@ export class CreateConnection extends Message<CreateConnection> {
    */
   type = ConnectionType.INVALID;
 
+  /**
+   * @generated from field: string provider_key = 3;
+   */
+  providerKey = "";
+
+  /**
+   * @generated from field: optional string key_id = 4;
+   */
+  keyId?: string;
+
   constructor(data?: PartialMessage<CreateConnection>) {
     super();
     proto3.util.initPartial(data, this);
@@ -703,6 +824,8 @@ export class CreateConnection extends Message<CreateConnection> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "provider", kind: "enum", T: proto3.getEnumType(ConnectionProvider) },
     { no: 2, name: "type", kind: "enum", T: proto3.getEnumType(ConnectionType) },
+    { no: 3, name: "provider_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "key_id", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateConnection {
@@ -818,12 +941,28 @@ export class Connection extends Message<Connection> {
      */
     value: PasswordLessConfig;
     case: "passwordlessConfig";
+  } | {
+    /**
+     * @generated from field: scalekit.v1.connections.StaticAuthConfig static_config = 26;
+     */
+    value: StaticAuthConfig;
+    case: "staticConfig";
   } | { case: undefined; value?: undefined } = { case: undefined };
 
   /**
-   * @generated from field: optional string key_id = 21;
+   * @generated from field: optional string key_id = 25;
    */
   keyId?: string;
+
+  /**
+   * @generated from field: string provider_key = 23;
+   */
+  providerKey = "";
+
+  /**
+   * @generated from field: repeated scalekit.v1.domains.Domain domains = 24;
+   */
+  domains: Domain[] = [];
 
   constructor(data?: PartialMessage<Connection>) {
     super();
@@ -850,7 +989,10 @@ export class Connection extends Message<Connection> {
     { no: 19, name: "saml_config", kind: "message", T: SAMLConnectionConfigResponse, oneof: "settings" },
     { no: 20, name: "oauth_config", kind: "message", T: OAuthConnectionConfig, oneof: "settings" },
     { no: 22, name: "passwordless_config", kind: "message", T: PasswordLessConfig, oneof: "settings" },
-    { no: 21, name: "key_id", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 26, name: "static_config", kind: "message", T: StaticAuthConfig, oneof: "settings" },
+    { no: 25, name: "key_id", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 23, name: "provider_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 24, name: "domains", kind: "message", T: Domain, repeated: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Connection {
@@ -1060,12 +1202,23 @@ export class UpdateConnection extends Message<UpdateConnection> {
      */
     value: PasswordLessConfig;
     case: "passwordlessConfig";
+  } | {
+    /**
+     * @generated from field: scalekit.v1.connections.StaticAuthConfig static_config = 23;
+     */
+    value: StaticAuthConfig;
+    case: "staticConfig";
   } | { case: undefined; value?: undefined } = { case: undefined };
 
   /**
-   * @generated from field: optional string key_id = 19;
+   * @generated from field: optional string key_id = 22;
    */
   keyId?: string;
+
+  /**
+   * @generated from field: string provider_key = 21;
+   */
+  providerKey = "";
 
   constructor(data?: PartialMessage<UpdateConnection>) {
     super();
@@ -1085,7 +1238,9 @@ export class UpdateConnection extends Message<UpdateConnection> {
     { no: 17, name: "saml_config", kind: "message", T: SAMLConnectionConfigRequest, oneof: "settings" },
     { no: 18, name: "oauth_config", kind: "message", T: OAuthConnectionConfig, oneof: "settings" },
     { no: 20, name: "passwordless_config", kind: "message", T: PasswordLessConfig, oneof: "settings" },
-    { no: 19, name: "key_id", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 23, name: "static_config", kind: "message", T: StaticAuthConfig, oneof: "settings" },
+    { no: 22, name: "key_id", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 21, name: "provider_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdateConnection {
@@ -1474,6 +1629,21 @@ export class ListConnection extends Message<ListConnection> {
    */
   organizationName = "";
 
+  /**
+   * @generated from field: string provider_key = 10;
+   */
+  providerKey = "";
+
+  /**
+   * @generated from field: string key_id = 11;
+   */
+  keyId = "";
+
+  /**
+   * @generated from field: google.protobuf.Timestamp created_at = 12;
+   */
+  createdAt?: Timestamp;
+
   constructor(data?: PartialMessage<ListConnection>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1491,6 +1661,9 @@ export class ListConnection extends Message<ListConnection> {
     { no: 7, name: "ui_button_title", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 8, name: "domains", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
     { no: 9, name: "organization_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 10, name: "provider_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 11, name: "key_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 12, name: "created_at", kind: "message", T: Timestamp },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListConnection {
@@ -1618,9 +1791,9 @@ export class SearchOrganizationConnectionsRequest extends Message<SearchOrganiza
   query?: string;
 
   /**
-   * @generated from field: optional scalekit.v1.connections.ConnectionProvider provider = 2;
+   * @generated from field: optional string provider = 2;
    */
-  provider?: ConnectionProvider;
+  provider?: string;
 
   /**
    * @generated from field: optional scalekit.v1.connections.ConnectionStatus status = 3;
@@ -1631,6 +1804,11 @@ export class SearchOrganizationConnectionsRequest extends Message<SearchOrganiza
    * @generated from field: optional scalekit.v1.connections.ConnectionType connection_type = 4;
    */
   connectionType?: ConnectionType;
+
+  /**
+   * @generated from field: optional bool enabled = 7;
+   */
+  enabled?: boolean;
 
   /**
    * @generated from field: uint32 page_size = 5;
@@ -1651,9 +1829,10 @@ export class SearchOrganizationConnectionsRequest extends Message<SearchOrganiza
   static readonly typeName = "scalekit.v1.connections.SearchOrganizationConnectionsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "query", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
-    { no: 2, name: "provider", kind: "enum", T: proto3.getEnumType(ConnectionProvider), opt: true },
+    { no: 2, name: "provider", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 3, name: "status", kind: "enum", T: proto3.getEnumType(ConnectionStatus), opt: true },
     { no: 4, name: "connection_type", kind: "enum", T: proto3.getEnumType(ConnectionType), opt: true },
+    { no: 7, name: "enabled", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
     { no: 5, name: "page_size", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
     { no: 6, name: "page_token", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
@@ -2028,6 +2207,11 @@ export class OAuthConnectionConfig extends Message<OAuthConnectionConfig> {
    */
   usePlatformCreds?: boolean;
 
+  /**
+   * @generated from field: google.protobuf.StringValue access_type = 16;
+   */
+  accessType?: string;
+
   constructor(data?: PartialMessage<OAuthConnectionConfig>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2046,6 +2230,7 @@ export class OAuthConnectionConfig extends Message<OAuthConnectionConfig> {
     { no: 13, name: "pkce_enabled", kind: "message", T: BoolValue },
     { no: 14, name: "prompt", kind: "message", T: StringValue },
     { no: 15, name: "use_platform_creds", kind: "message", T: BoolValue },
+    { no: 16, name: "access_type", kind: "message", T: StringValue },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): OAuthConnectionConfig {
@@ -2099,6 +2284,11 @@ export class PasswordLessConfig extends Message<PasswordLessConfig> {
    */
   codeChallengeType?: CodeChallengeType;
 
+  /**
+   * @generated from field: optional google.protobuf.BoolValue regenerate_passwordless_credentials_on_resend = 7;
+   */
+  regeneratePasswordlessCredentialsOnResend?: boolean;
+
   constructor(data?: PartialMessage<PasswordLessConfig>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2113,6 +2303,7 @@ export class PasswordLessConfig extends Message<PasswordLessConfig> {
     { no: 4, name: "enforce_same_browser_origin", kind: "message", T: BoolValue, opt: true },
     { no: 5, name: "code_challenge_length", kind: "message", T: UInt32Value, opt: true },
     { no: 6, name: "code_challenge_type", kind: "enum", T: proto3.getEnumType(CodeChallengeType), opt: true },
+    { no: 7, name: "regenerate_passwordless_credentials_on_resend", kind: "message", T: BoolValue, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PasswordLessConfig {
@@ -2129,6 +2320,43 @@ export class PasswordLessConfig extends Message<PasswordLessConfig> {
 
   static equals(a: PasswordLessConfig | PlainMessage<PasswordLessConfig> | undefined, b: PasswordLessConfig | PlainMessage<PasswordLessConfig> | undefined): boolean {
     return proto3.util.equals(PasswordLessConfig, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.connections.StaticAuthConfig
+ */
+export class StaticAuthConfig extends Message<StaticAuthConfig> {
+  /**
+   * @generated from field: google.protobuf.Struct static_config = 1;
+   */
+  staticConfig?: Struct;
+
+  constructor(data?: PartialMessage<StaticAuthConfig>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.connections.StaticAuthConfig";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "static_config", kind: "message", T: Struct },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): StaticAuthConfig {
+    return new StaticAuthConfig().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): StaticAuthConfig {
+    return new StaticAuthConfig().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): StaticAuthConfig {
+    return new StaticAuthConfig().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: StaticAuthConfig | PlainMessage<StaticAuthConfig> | undefined, b: StaticAuthConfig | PlainMessage<StaticAuthConfig> | undefined): boolean {
+    return proto3.util.equals(StaticAuthConfig, a, b);
   }
 }
 
@@ -3026,6 +3254,147 @@ export class PasswordConnectionConfig extends Message<PasswordConnectionConfig> 
 
   static equals(a: PasswordConnectionConfig | PlainMessage<PasswordConnectionConfig> | undefined, b: PasswordConnectionConfig | PlainMessage<PasswordConnectionConfig> | undefined): boolean {
     return proto3.util.equals(PasswordConnectionConfig, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.connections.Flags
+ */
+export class Flags extends Message<Flags> {
+  /**
+   * @generated from field: bool is_login = 1;
+   */
+  isLogin = false;
+
+  /**
+   * @generated from field: bool is_app = 2;
+   */
+  isApp = false;
+
+  constructor(data?: PartialMessage<Flags>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.connections.Flags";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "is_login", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 2, name: "is_app", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Flags {
+    return new Flags().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): Flags {
+    return new Flags().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): Flags {
+    return new Flags().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: Flags | PlainMessage<Flags> | undefined, b: Flags | PlainMessage<Flags> | undefined): boolean {
+    return proto3.util.equals(Flags, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.connections.ListAppConnectionsRequest
+ */
+export class ListAppConnectionsRequest extends Message<ListAppConnectionsRequest> {
+  /**
+   * @generated from field: uint32 page_size = 1;
+   */
+  pageSize = 0;
+
+  /**
+   * @generated from field: string page_token = 2;
+   */
+  pageToken = "";
+
+  constructor(data?: PartialMessage<ListAppConnectionsRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.connections.ListAppConnectionsRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "page_size", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
+    { no: 2, name: "page_token", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListAppConnectionsRequest {
+    return new ListAppConnectionsRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ListAppConnectionsRequest {
+    return new ListAppConnectionsRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ListAppConnectionsRequest {
+    return new ListAppConnectionsRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ListAppConnectionsRequest | PlainMessage<ListAppConnectionsRequest> | undefined, b: ListAppConnectionsRequest | PlainMessage<ListAppConnectionsRequest> | undefined): boolean {
+    return proto3.util.equals(ListAppConnectionsRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.connections.ListAppConnectionsResponse
+ */
+export class ListAppConnectionsResponse extends Message<ListAppConnectionsResponse> {
+  /**
+   * @generated from field: repeated scalekit.v1.connections.ListConnection connections = 1;
+   */
+  connections: ListConnection[] = [];
+
+  /**
+   * @generated from field: string next_page_token = 2;
+   */
+  nextPageToken = "";
+
+  /**
+   * @generated from field: string prev_page_token = 3;
+   */
+  prevPageToken = "";
+
+  /**
+   * @generated from field: uint32 total_size = 4;
+   */
+  totalSize = 0;
+
+  constructor(data?: PartialMessage<ListAppConnectionsResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.connections.ListAppConnectionsResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "connections", kind: "message", T: ListConnection, repeated: true },
+    { no: 2, name: "next_page_token", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "prev_page_token", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "total_size", kind: "scalar", T: 13 /* ScalarType.UINT32 */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListAppConnectionsResponse {
+    return new ListAppConnectionsResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ListAppConnectionsResponse {
+    return new ListAppConnectionsResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ListAppConnectionsResponse {
+    return new ListAppConnectionsResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ListAppConnectionsResponse | PlainMessage<ListAppConnectionsResponse> | undefined, b: ListAppConnectionsResponse | PlainMessage<ListAppConnectionsResponse> | undefined): boolean {
+    return proto3.util.equals(ListAppConnectionsResponse, a, b);
   }
 }
 

--- a/src/pkg/grpc/scalekit/v1/domains/domains_pb.ts
+++ b/src/pkg/grpc/scalekit/v1/domains/domains_pb.ts
@@ -39,6 +39,32 @@ proto3.util.setEnumType(VerificationStatus, "scalekit.v1.domains.VerificationSta
 ]);
 
 /**
+ * @generated from enum scalekit.v1.domains.DomainType
+ */
+export enum DomainType {
+  /**
+   * @generated from enum value: DOMAIN_TYPE_UNSPECIFIED = 0;
+   */
+  DOMAIN_TYPE_UNSPECIFIED = 0,
+
+  /**
+   * @generated from enum value: HOME_REALM_DISCOVERY = 1;
+   */
+  HOME_REALM_DISCOVERY = 1,
+
+  /**
+   * @generated from enum value: JIT_PROVISIONING_DOMAIN = 2;
+   */
+  JIT_PROVISIONING_DOMAIN = 2,
+}
+// Retrieve enum metadata with: proto3.getEnumType(DomainType)
+proto3.util.setEnumType(DomainType, "scalekit.v1.domains.DomainType", [
+  { no: 0, name: "DOMAIN_TYPE_UNSPECIFIED" },
+  { no: 1, name: "HOME_REALM_DISCOVERY" },
+  { no: 2, name: "JIT_PROVISIONING_DOMAIN" },
+]);
+
+/**
  * @generated from message scalekit.v1.domains.CreateDomainRequest
  */
 export class CreateDomainRequest extends Message<CreateDomainRequest> {
@@ -146,6 +172,11 @@ export class CreateDomain extends Message<CreateDomain> {
    */
   domain = "";
 
+  /**
+   * @generated from field: scalekit.v1.domains.DomainType domain_type = 2;
+   */
+  domainType = DomainType.DOMAIN_TYPE_UNSPECIFIED;
+
   constructor(data?: PartialMessage<CreateDomain>) {
     super();
     proto3.util.initPartial(data, this);
@@ -155,6 +186,7 @@ export class CreateDomain extends Message<CreateDomain> {
   static readonly typeName = "scalekit.v1.domains.CreateDomain";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "domain", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "domain_type", kind: "enum", T: proto3.getEnumType(DomainType) },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateDomain {
@@ -506,6 +538,11 @@ export class ListDomainRequest extends Message<ListDomainRequest> {
    */
   pageNumber?: number;
 
+  /**
+   * @generated from field: scalekit.v1.domains.DomainType domain_type = 7;
+   */
+  domainType = DomainType.DOMAIN_TYPE_UNSPECIFIED;
+
   constructor(data?: PartialMessage<ListDomainRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -520,6 +557,7 @@ export class ListDomainRequest extends Message<ListDomainRequest> {
     { no: 4, name: "include", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 5, name: "page_size", kind: "message", T: Int32Value },
     { no: 6, name: "page_number", kind: "message", T: Int32Value },
+    { no: 7, name: "domain_type", kind: "enum", T: proto3.getEnumType(DomainType) },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListDomainRequest {
@@ -777,6 +815,11 @@ export class Domain extends Message<Domain> {
    */
   createdBy?: string;
 
+  /**
+   * @generated from field: scalekit.v1.domains.DomainType domain_type = 12;
+   */
+  domainType = DomainType.DOMAIN_TYPE_UNSPECIFIED;
+
   constructor(data?: PartialMessage<Domain>) {
     super();
     proto3.util.initPartial(data, this);
@@ -796,6 +839,7 @@ export class Domain extends Message<Domain> {
     { no: 9, name: "create_time", kind: "message", T: Timestamp },
     { no: 10, name: "update_time", kind: "message", T: Timestamp },
     { no: 11, name: "created_by", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 12, name: "domain_type", kind: "enum", T: proto3.getEnumType(DomainType) },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Domain {

--- a/src/pkg/grpc/scalekit/v1/errdetails/errdetails_pb.ts
+++ b/src/pkg/grpc/scalekit/v1/errdetails/errdetails_pb.ts
@@ -45,6 +45,11 @@ export class ErrorInfo extends Message<ErrorInfo> {
    */
   validationErrorInfo?: ValidationErrorInfo;
 
+  /**
+   * @generated from field: optional scalekit.v1.errdetails.ToolErrorInfo tool_error_info = 9;
+   */
+  toolErrorInfo?: ToolErrorInfo;
+
   constructor(data?: PartialMessage<ErrorInfo>) {
     super();
     proto3.util.initPartial(data, this);
@@ -60,6 +65,7 @@ export class ErrorInfo extends Message<ErrorInfo> {
     { no: 5, name: "resource_info", kind: "message", T: ResourceInfo, opt: true },
     { no: 6, name: "request_info", kind: "message", T: RequestInfo, opt: true },
     { no: 8, name: "validation_error_info", kind: "message", T: ValidationErrorInfo, opt: true },
+    { no: 9, name: "tool_error_info", kind: "message", T: ToolErrorInfo, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ErrorInfo {
@@ -456,6 +462,49 @@ export class LocalizedMessageInfo extends Message<LocalizedMessageInfo> {
 
   static equals(a: LocalizedMessageInfo | PlainMessage<LocalizedMessageInfo> | undefined, b: LocalizedMessageInfo | PlainMessage<LocalizedMessageInfo> | undefined): boolean {
     return proto3.util.equals(LocalizedMessageInfo, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.errdetails.ToolErrorInfo
+ */
+export class ToolErrorInfo extends Message<ToolErrorInfo> {
+  /**
+   * @generated from field: string execution_id = 1;
+   */
+  executionId = "";
+
+  /**
+   * @generated from field: string tool_message = 2;
+   */
+  toolMessage = "";
+
+  constructor(data?: PartialMessage<ToolErrorInfo>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.errdetails.ToolErrorInfo";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "execution_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "tool_message", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ToolErrorInfo {
+    return new ToolErrorInfo().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ToolErrorInfo {
+    return new ToolErrorInfo().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ToolErrorInfo {
+    return new ToolErrorInfo().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ToolErrorInfo | PlainMessage<ToolErrorInfo> | undefined, b: ToolErrorInfo | PlainMessage<ToolErrorInfo> | undefined): boolean {
+    return proto3.util.equals(ToolErrorInfo, a, b);
   }
 }
 

--- a/src/pkg/grpc/scalekit/v1/organizations/organizations_connect.ts
+++ b/src/pkg/grpc/scalekit/v1/organizations/organizations_connect.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { CreateOrganizationRequest, CreateOrganizationResponse, CreateOrganizationSessionSettingsRequest, CreateOrganizationSessionSettingsResponse, DeleteOrganizationRequest, DeleteOrganizationSessionSettingsRequest, DeletePortalLinkByIdRequest, DeletePortalLinkRequest, GeneratePortalLinkRequest, GeneratePortalLinkResponse, GetOrganizationRequest, GetOrganizationResponse, GetOrganizationSessionSettingsRequest, GetOrganizationSessionSettingsResponse, GetPortalLinkRequest, GetPortalLinksResponse, ListOrganizationsRequest, ListOrganizationsResponse, SearchOrganizationsRequest, SearchOrganizationsResponse, UpdateOrganizationRequest, UpdateOrganizationResponse, UpdateOrganizationSessionSettingsRequest, UpdateOrganizationSessionSettingsResponse, UpdateOrganizationSettingsRequest } from "./organizations_pb.js";
+import { CreateOrganizationRequest, CreateOrganizationResponse, CreateOrganizationSessionSettingsRequest, CreateOrganizationSessionSettingsResponse, DeleteOrganizationRequest, DeleteOrganizationSessionSettingsRequest, DeletePortalLinkByIdRequest, DeletePortalLinkRequest, GeneratePortalLinkRequest, GeneratePortalLinkResponse, GetOrganizationRequest, GetOrganizationResponse, GetOrganizationSessionSettingsRequest, GetOrganizationSessionSettingsResponse, GetOrganizationUserManagementSettingsRequest, GetOrganizationUserManagementSettingsResponse, GetPortalLinkRequest, GetPortalLinksResponse, ListOrganizationsRequest, ListOrganizationsResponse, SearchOrganizationsRequest, SearchOrganizationsResponse, UpdateOrganizationRequest, UpdateOrganizationResponse, UpdateOrganizationSessionSettingsRequest, UpdateOrganizationSessionSettingsResponse, UpdateOrganizationSettingsRequest, UpdateUserManagementSettingsRequest, UpdateUserManagementSettingsResponse } from "./organizations_pb.js";
 import { Empty, MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -151,6 +151,26 @@ export const OrganizationService = {
       name: "DeleteOrganizationSessionSettings",
       I: DeleteOrganizationSessionSettingsRequest,
       O: Empty,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * Update user management setting for an organization
+     *
+     * @generated from rpc scalekit.v1.organizations.OrganizationService.UpdateUserManagementSettings
+     */
+    updateUserManagementSettings: {
+      name: "UpdateUserManagementSettings",
+      I: UpdateUserManagementSettingsRequest,
+      O: UpdateUserManagementSettingsResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * @generated from rpc scalekit.v1.organizations.OrganizationService.GetOrganizationUserManagementSetting
+     */
+    getOrganizationUserManagementSetting: {
+      name: "GetOrganizationUserManagementSetting",
+      I: GetOrganizationUserManagementSettingsRequest,
+      O: GetOrganizationUserManagementSettingsResponse,
       kind: MethodKind.Unary,
     },
   }

--- a/src/pkg/grpc/scalekit/v1/organizations/organizations_pb.ts
+++ b/src/pkg/grpc/scalekit/v1/organizations/organizations_pb.ts
@@ -4,7 +4,7 @@
 // @ts-nocheck
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
-import { BoolValue, FieldMask, Int32Value, Message, proto3, Timestamp } from "@bufbuild/protobuf";
+import { BoolValue, FieldMask, Int32Value, Message, NullValue, proto3, Timestamp } from "@bufbuild/protobuf";
 import { RegionCode } from "../commons/commons_pb.js";
 
 /**
@@ -14,21 +14,27 @@ import { RegionCode } from "../commons/commons_pb.js";
  */
 export enum Feature {
   /**
-   * UNSPECIFIED represents an unset or invalid feature value
+   * An unspecified or invalid feature value
    *
-   * @generated from enum value: UNSPECIFIED = 0;
+   * @generated from enum value: FEATURE_UNSPECIFIED = 0;
+   */
+  FEATURE_UNSPECIFIED = 0,
+
+  /**
+   * @generated from enum value: UNSPECIFIED = 0 [deprecated = true];
+   * @deprecated
    */
   UNSPECIFIED = 0,
 
   /**
-   * dir_sync enables directory synchronization configuration in the portal
+   * Enables directory synchronization configuration in the portal
    *
    * @generated from enum value: dir_sync = 1;
    */
   dir_sync = 1,
 
   /**
-   * sso enables Single Sign-On (SSO) configuration in the portal
+   * Enables Single Sign-On (SSO) configuration in the portal
    *
    * @generated from enum value: sso = 2;
    */
@@ -36,6 +42,7 @@ export enum Feature {
 }
 // Retrieve enum metadata with: proto3.getEnumType(Feature)
 proto3.util.setEnumType(Feature, "scalekit.v1.organizations.Feature", [
+  { no: 0, name: "FEATURE_UNSPECIFIED" },
   { no: 0, name: "UNSPECIFIED" },
   { no: 1, name: "dir_sync" },
   { no: 2, name: "sso" },
@@ -1205,6 +1212,58 @@ export class UpdateOrganizationSessionSettingsResponse extends Message<UpdateOrg
 }
 
 /**
+ * @generated from message scalekit.v1.organizations.OrganizationUserManagementSettings
+ */
+export class OrganizationUserManagementSettings extends Message<OrganizationUserManagementSettings> {
+  /**
+   * @generated from field: google.protobuf.BoolValue jit_provisioning_with_sso_enabled = 1;
+   */
+  jitProvisioningWithSsoEnabled?: boolean;
+
+  /**
+   * @generated from field: google.protobuf.BoolValue sync_user_profile_on_signin = 2;
+   */
+  syncUserProfileOnSignin?: boolean;
+
+  /**
+   * Deprecated placeholder to ensure google.protobuf.NullValue is referenced in the schema, preventing unused-definition warnings.
+   *
+   * @generated from field: google.protobuf.NullValue deprecated_placeholder = 99 [deprecated = true];
+   * @deprecated
+   */
+  deprecatedPlaceholder = NullValue.NULL_VALUE;
+
+  constructor(data?: PartialMessage<OrganizationUserManagementSettings>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.organizations.OrganizationUserManagementSettings";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "jit_provisioning_with_sso_enabled", kind: "message", T: BoolValue },
+    { no: 2, name: "sync_user_profile_on_signin", kind: "message", T: BoolValue },
+    { no: 99, name: "deprecated_placeholder", kind: "enum", T: proto3.getEnumType(NullValue) },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): OrganizationUserManagementSettings {
+    return new OrganizationUserManagementSettings().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): OrganizationUserManagementSettings {
+    return new OrganizationUserManagementSettings().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): OrganizationUserManagementSettings {
+    return new OrganizationUserManagementSettings().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: OrganizationUserManagementSettings | PlainMessage<OrganizationUserManagementSettings> | undefined, b: OrganizationUserManagementSettings | PlainMessage<OrganizationUserManagementSettings> | undefined): boolean {
+    return proto3.util.equals(OrganizationUserManagementSettings, a, b);
+  }
+}
+
+/**
  * @generated from message scalekit.v1.organizations.OrganizationSessionSettings
  */
 export class OrganizationSessionSettings extends Message<OrganizationSessionSettings> {
@@ -1563,6 +1622,160 @@ export class OrganizationSettingsFeature extends Message<OrganizationSettingsFea
 
   static equals(a: OrganizationSettingsFeature | PlainMessage<OrganizationSettingsFeature> | undefined, b: OrganizationSettingsFeature | PlainMessage<OrganizationSettingsFeature> | undefined): boolean {
     return proto3.util.equals(OrganizationSettingsFeature, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.organizations.UpdateUserManagementSettingsRequest
+ */
+export class UpdateUserManagementSettingsRequest extends Message<UpdateUserManagementSettingsRequest> {
+  /**
+   * @generated from field: string organization_id = 1;
+   */
+  organizationId = "";
+
+  /**
+   * @generated from field: scalekit.v1.organizations.OrganizationUserManagementSettings settings = 2;
+   */
+  settings?: OrganizationUserManagementSettings;
+
+  constructor(data?: PartialMessage<UpdateUserManagementSettingsRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.organizations.UpdateUserManagementSettingsRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "settings", kind: "message", T: OrganizationUserManagementSettings },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdateUserManagementSettingsRequest {
+    return new UpdateUserManagementSettingsRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): UpdateUserManagementSettingsRequest {
+    return new UpdateUserManagementSettingsRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): UpdateUserManagementSettingsRequest {
+    return new UpdateUserManagementSettingsRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: UpdateUserManagementSettingsRequest | PlainMessage<UpdateUserManagementSettingsRequest> | undefined, b: UpdateUserManagementSettingsRequest | PlainMessage<UpdateUserManagementSettingsRequest> | undefined): boolean {
+    return proto3.util.equals(UpdateUserManagementSettingsRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.organizations.UpdateUserManagementSettingsResponse
+ */
+export class UpdateUserManagementSettingsResponse extends Message<UpdateUserManagementSettingsResponse> {
+  /**
+   * @generated from field: scalekit.v1.organizations.OrganizationUserManagementSettings settings = 1;
+   */
+  settings?: OrganizationUserManagementSettings;
+
+  constructor(data?: PartialMessage<UpdateUserManagementSettingsResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.organizations.UpdateUserManagementSettingsResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "settings", kind: "message", T: OrganizationUserManagementSettings },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdateUserManagementSettingsResponse {
+    return new UpdateUserManagementSettingsResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): UpdateUserManagementSettingsResponse {
+    return new UpdateUserManagementSettingsResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): UpdateUserManagementSettingsResponse {
+    return new UpdateUserManagementSettingsResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: UpdateUserManagementSettingsResponse | PlainMessage<UpdateUserManagementSettingsResponse> | undefined, b: UpdateUserManagementSettingsResponse | PlainMessage<UpdateUserManagementSettingsResponse> | undefined): boolean {
+    return proto3.util.equals(UpdateUserManagementSettingsResponse, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.organizations.GetOrganizationUserManagementSettingsRequest
+ */
+export class GetOrganizationUserManagementSettingsRequest extends Message<GetOrganizationUserManagementSettingsRequest> {
+  /**
+   * @generated from field: string organization_id = 1;
+   */
+  organizationId = "";
+
+  constructor(data?: PartialMessage<GetOrganizationUserManagementSettingsRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.organizations.GetOrganizationUserManagementSettingsRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetOrganizationUserManagementSettingsRequest {
+    return new GetOrganizationUserManagementSettingsRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): GetOrganizationUserManagementSettingsRequest {
+    return new GetOrganizationUserManagementSettingsRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): GetOrganizationUserManagementSettingsRequest {
+    return new GetOrganizationUserManagementSettingsRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: GetOrganizationUserManagementSettingsRequest | PlainMessage<GetOrganizationUserManagementSettingsRequest> | undefined, b: GetOrganizationUserManagementSettingsRequest | PlainMessage<GetOrganizationUserManagementSettingsRequest> | undefined): boolean {
+    return proto3.util.equals(GetOrganizationUserManagementSettingsRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.organizations.GetOrganizationUserManagementSettingsResponse
+ */
+export class GetOrganizationUserManagementSettingsResponse extends Message<GetOrganizationUserManagementSettingsResponse> {
+  /**
+   * @generated from field: scalekit.v1.organizations.OrganizationUserManagementSettings settings = 1;
+   */
+  settings?: OrganizationUserManagementSettings;
+
+  constructor(data?: PartialMessage<GetOrganizationUserManagementSettingsResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.organizations.GetOrganizationUserManagementSettingsResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "settings", kind: "message", T: OrganizationUserManagementSettings },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetOrganizationUserManagementSettingsResponse {
+    return new GetOrganizationUserManagementSettingsResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): GetOrganizationUserManagementSettingsResponse {
+    return new GetOrganizationUserManagementSettingsResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): GetOrganizationUserManagementSettingsResponse {
+    return new GetOrganizationUserManagementSettingsResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: GetOrganizationUserManagementSettingsResponse | PlainMessage<GetOrganizationUserManagementSettingsResponse> | undefined, b: GetOrganizationUserManagementSettingsResponse | PlainMessage<GetOrganizationUserManagementSettingsResponse> | undefined): boolean {
+    return proto3.util.equals(GetOrganizationUserManagementSettingsResponse, a, b);
   }
 }
 

--- a/src/pkg/grpc/scalekit/v1/users/users_connect.ts
+++ b/src/pkg/grpc/scalekit/v1/users/users_connect.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { CreateMembershipRequest, CreateMembershipResponse, CreateUserAndMembershipRequest, CreateUserAndMembershipResponse, DeleteMembershipRequest, DeleteUserRequest, GetUserRequest, GetUserResponse, ListOrganizationUsersRequest, ListOrganizationUsersResponse, ListUsersRequest, ListUsersResponse, SearchOrganizationUsersRequest, SearchOrganizationUsersResponse, SearchUsersRequest, SearchUsersResponse, UpdateMembershipRequest, UpdateMembershipResponse, UpdateUserRequest, UpdateUserResponse } from "./users_pb.js";
+import { AssignUserRolesRequest, AssignUserRolesResponse, CreateMembershipRequest, CreateMembershipResponse, CreateUserAndMembershipRequest, CreateUserAndMembershipResponse, DeleteMembershipRequest, DeleteUserRequest, GetUserRequest, GetUserResponse, ListOrganizationUsersRequest, ListOrganizationUsersResponse, ListUserPermissionsRequest, ListUserPermissionsResponse, ListUserRolesRequest, ListUserRolesResponse, ListUsersRequest, ListUsersResponse, RemoveUserRoleRequest, ResendInviteRequest, ResendInviteResponse, SearchOrganizationUsersRequest, SearchOrganizationUsersResponse, SearchUsersRequest, SearchUsersResponse, UpdateMembershipRequest, UpdateMembershipResponse, UpdateUserRequest, UpdateUserResponse } from "./users_pb.js";
 import { Empty, MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -117,6 +117,53 @@ export const UserService = {
       name: "ListOrganizationUsers",
       I: ListOrganizationUsersRequest,
       O: ListOrganizationUsersResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * @generated from rpc scalekit.v1.users.UserService.ResendInvite
+     */
+    resendInvite: {
+      name: "ResendInvite",
+      I: ResendInviteRequest,
+      O: ResendInviteResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * User Role Management
+     *
+     * @generated from rpc scalekit.v1.users.UserService.ListUserRoles
+     */
+    listUserRoles: {
+      name: "ListUserRoles",
+      I: ListUserRolesRequest,
+      O: ListUserRolesResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * @generated from rpc scalekit.v1.users.UserService.AssignUserRoles
+     */
+    assignUserRoles: {
+      name: "AssignUserRoles",
+      I: AssignUserRolesRequest,
+      O: AssignUserRolesResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * @generated from rpc scalekit.v1.users.UserService.RemoveUserRole
+     */
+    removeUserRole: {
+      name: "RemoveUserRole",
+      I: RemoveUserRoleRequest,
+      O: Empty,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * @generated from rpc scalekit.v1.users.UserService.ListUserPermissions
+     */
+    listUserPermissions: {
+      name: "ListUserPermissions",
+      I: ListUserPermissionsRequest,
+      O: ListUserPermissionsResponse,
       kind: MethodKind.Unary,
     },
   }

--- a/src/pkg/grpc/scalekit/v1/users/users_pb.ts
+++ b/src/pkg/grpc/scalekit/v1/users/users_pb.ts
@@ -113,9 +113,9 @@ export class CreateUserAndMembershipRequest extends Message<CreateUserAndMembers
   user?: CreateUser;
 
   /**
-   * @generated from field: bool send_activation_email = 3;
+   * @generated from field: optional bool send_invitation_email = 3;
    */
-  sendActivationEmail = false;
+  sendInvitationEmail?: boolean;
 
   constructor(data?: PartialMessage<CreateUserAndMembershipRequest>) {
     super();
@@ -127,7 +127,7 @@ export class CreateUserAndMembershipRequest extends Message<CreateUserAndMembers
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "user", kind: "message", T: CreateUser },
-    { no: 3, name: "send_activation_email", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 3, name: "send_invitation_email", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateUserAndMembershipRequest {
@@ -611,9 +611,9 @@ export class CreateMembershipRequest extends Message<CreateMembershipRequest> {
   } | { case: undefined; value?: undefined } = { case: undefined };
 
   /**
-   * @generated from field: bool send_activation_email = 5;
+   * @generated from field: optional bool send_invitation_email = 5;
    */
-  sendActivationEmail = false;
+  sendInvitationEmail?: boolean;
 
   constructor(data?: PartialMessage<CreateMembershipRequest>) {
     super();
@@ -627,7 +627,7 @@ export class CreateMembershipRequest extends Message<CreateMembershipRequest> {
     { no: 2, name: "membership", kind: "message", T: CreateMembership },
     { no: 3, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */, oneof: "identities" },
     { no: 4, name: "external_id", kind: "scalar", T: 9 /* ScalarType.STRING */, oneof: "identities" },
-    { no: 5, name: "send_activation_email", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 5, name: "send_invitation_email", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateMembershipRequest {
@@ -1435,6 +1435,558 @@ export class UpdateUserProfile extends Message<UpdateUserProfile> {
 
   static equals(a: UpdateUserProfile | PlainMessage<UpdateUserProfile> | undefined, b: UpdateUserProfile | PlainMessage<UpdateUserProfile> | undefined): boolean {
     return proto3.util.equals(UpdateUserProfile, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.users.Invite
+ */
+export class Invite extends Message<Invite> {
+  /**
+   * @generated from field: string organization_id = 1;
+   */
+  organizationId = "";
+
+  /**
+   * @generated from field: string user_id = 2;
+   */
+  userId = "";
+
+  /**
+   * @generated from field: string invited_by = 3;
+   */
+  invitedBy = "";
+
+  /**
+   * @generated from field: string status = 4;
+   */
+  status = "";
+
+  /**
+   * @generated from field: google.protobuf.Timestamp created_at = 5;
+   */
+  createdAt?: Timestamp;
+
+  /**
+   * @generated from field: google.protobuf.Timestamp expires_at = 6;
+   */
+  expiresAt?: Timestamp;
+
+  /**
+   * @generated from field: google.protobuf.Timestamp resent_at = 7;
+   */
+  resentAt?: Timestamp;
+
+  /**
+   * @generated from field: int32 resent_count = 8;
+   */
+  resentCount = 0;
+
+  constructor(data?: PartialMessage<Invite>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.users.Invite";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "invited_by", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "status", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 5, name: "created_at", kind: "message", T: Timestamp },
+    { no: 6, name: "expires_at", kind: "message", T: Timestamp },
+    { no: 7, name: "resent_at", kind: "message", T: Timestamp },
+    { no: 8, name: "resent_count", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Invite {
+    return new Invite().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): Invite {
+    return new Invite().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): Invite {
+    return new Invite().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: Invite | PlainMessage<Invite> | undefined, b: Invite | PlainMessage<Invite> | undefined): boolean {
+    return proto3.util.equals(Invite, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.users.ResendInviteRequest
+ */
+export class ResendInviteRequest extends Message<ResendInviteRequest> {
+  /**
+   * @generated from field: string organization_id = 1;
+   */
+  organizationId = "";
+
+  /**
+   * @generated from field: string id = 2;
+   */
+  id = "";
+
+  constructor(data?: PartialMessage<ResendInviteRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.users.ResendInviteRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ResendInviteRequest {
+    return new ResendInviteRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ResendInviteRequest {
+    return new ResendInviteRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ResendInviteRequest {
+    return new ResendInviteRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ResendInviteRequest | PlainMessage<ResendInviteRequest> | undefined, b: ResendInviteRequest | PlainMessage<ResendInviteRequest> | undefined): boolean {
+    return proto3.util.equals(ResendInviteRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.users.ResendInviteResponse
+ */
+export class ResendInviteResponse extends Message<ResendInviteResponse> {
+  /**
+   * @generated from field: scalekit.v1.users.Invite invite = 1;
+   */
+  invite?: Invite;
+
+  constructor(data?: PartialMessage<ResendInviteResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.users.ResendInviteResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "invite", kind: "message", T: Invite },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ResendInviteResponse {
+    return new ResendInviteResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ResendInviteResponse {
+    return new ResendInviteResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ResendInviteResponse {
+    return new ResendInviteResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ResendInviteResponse | PlainMessage<ResendInviteResponse> | undefined, b: ResendInviteResponse | PlainMessage<ResendInviteResponse> | undefined): boolean {
+    return proto3.util.equals(ResendInviteResponse, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.users.ListUserRolesRequest
+ */
+export class ListUserRolesRequest extends Message<ListUserRolesRequest> {
+  /**
+   * @generated from field: string organization_id = 1;
+   */
+  organizationId = "";
+
+  /**
+   * @generated from field: string user_id = 2;
+   */
+  userId = "";
+
+  constructor(data?: PartialMessage<ListUserRolesRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.users.ListUserRolesRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListUserRolesRequest {
+    return new ListUserRolesRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ListUserRolesRequest {
+    return new ListUserRolesRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ListUserRolesRequest {
+    return new ListUserRolesRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ListUserRolesRequest | PlainMessage<ListUserRolesRequest> | undefined, b: ListUserRolesRequest | PlainMessage<ListUserRolesRequest> | undefined): boolean {
+    return proto3.util.equals(ListUserRolesRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.users.ListUserRolesResponse
+ */
+export class ListUserRolesResponse extends Message<ListUserRolesResponse> {
+  /**
+   * @generated from field: repeated scalekit.v1.commons.Role roles = 1;
+   */
+  roles: Role[] = [];
+
+  constructor(data?: PartialMessage<ListUserRolesResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.users.ListUserRolesResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "roles", kind: "message", T: Role, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListUserRolesResponse {
+    return new ListUserRolesResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ListUserRolesResponse {
+    return new ListUserRolesResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ListUserRolesResponse {
+    return new ListUserRolesResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ListUserRolesResponse | PlainMessage<ListUserRolesResponse> | undefined, b: ListUserRolesResponse | PlainMessage<ListUserRolesResponse> | undefined): boolean {
+    return proto3.util.equals(ListUserRolesResponse, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.users.AssignUserRolesRequest
+ */
+export class AssignUserRolesRequest extends Message<AssignUserRolesRequest> {
+  /**
+   * @generated from field: string organization_id = 1;
+   */
+  organizationId = "";
+
+  /**
+   * @generated from field: string user_id = 2;
+   */
+  userId = "";
+
+  /**
+   * @generated from field: repeated scalekit.v1.users.AssignRoleRequest roles = 3;
+   */
+  roles: AssignRoleRequest[] = [];
+
+  constructor(data?: PartialMessage<AssignUserRolesRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.users.AssignUserRolesRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "roles", kind: "message", T: AssignRoleRequest, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AssignUserRolesRequest {
+    return new AssignUserRolesRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): AssignUserRolesRequest {
+    return new AssignUserRolesRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): AssignUserRolesRequest {
+    return new AssignUserRolesRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: AssignUserRolesRequest | PlainMessage<AssignUserRolesRequest> | undefined, b: AssignUserRolesRequest | PlainMessage<AssignUserRolesRequest> | undefined): boolean {
+    return proto3.util.equals(AssignUserRolesRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.users.AssignRoleRequest
+ */
+export class AssignRoleRequest extends Message<AssignRoleRequest> {
+  /**
+   * @generated from field: string id = 1;
+   */
+  id = "";
+
+  constructor(data?: PartialMessage<AssignRoleRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.users.AssignRoleRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AssignRoleRequest {
+    return new AssignRoleRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): AssignRoleRequest {
+    return new AssignRoleRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): AssignRoleRequest {
+    return new AssignRoleRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: AssignRoleRequest | PlainMessage<AssignRoleRequest> | undefined, b: AssignRoleRequest | PlainMessage<AssignRoleRequest> | undefined): boolean {
+    return proto3.util.equals(AssignRoleRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.users.AssignUserRolesResponse
+ */
+export class AssignUserRolesResponse extends Message<AssignUserRolesResponse> {
+  /**
+   * @generated from field: repeated scalekit.v1.commons.Role roles = 1;
+   */
+  roles: Role[] = [];
+
+  constructor(data?: PartialMessage<AssignUserRolesResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.users.AssignUserRolesResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "roles", kind: "message", T: Role, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AssignUserRolesResponse {
+    return new AssignUserRolesResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): AssignUserRolesResponse {
+    return new AssignUserRolesResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): AssignUserRolesResponse {
+    return new AssignUserRolesResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: AssignUserRolesResponse | PlainMessage<AssignUserRolesResponse> | undefined, b: AssignUserRolesResponse | PlainMessage<AssignUserRolesResponse> | undefined): boolean {
+    return proto3.util.equals(AssignUserRolesResponse, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.users.RemoveUserRoleRequest
+ */
+export class RemoveUserRoleRequest extends Message<RemoveUserRoleRequest> {
+  /**
+   * @generated from field: string organization_id = 1;
+   */
+  organizationId = "";
+
+  /**
+   * @generated from field: string user_id = 2;
+   */
+  userId = "";
+
+  /**
+   * @generated from field: string role_id = 3;
+   */
+  roleId = "";
+
+  constructor(data?: PartialMessage<RemoveUserRoleRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.users.RemoveUserRoleRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "role_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RemoveUserRoleRequest {
+    return new RemoveUserRoleRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): RemoveUserRoleRequest {
+    return new RemoveUserRoleRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): RemoveUserRoleRequest {
+    return new RemoveUserRoleRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: RemoveUserRoleRequest | PlainMessage<RemoveUserRoleRequest> | undefined, b: RemoveUserRoleRequest | PlainMessage<RemoveUserRoleRequest> | undefined): boolean {
+    return proto3.util.equals(RemoveUserRoleRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.users.ListUserPermissionsRequest
+ */
+export class ListUserPermissionsRequest extends Message<ListUserPermissionsRequest> {
+  /**
+   * @generated from field: string organization_id = 1;
+   */
+  organizationId = "";
+
+  /**
+   * @generated from field: string user_id = 2;
+   */
+  userId = "";
+
+  constructor(data?: PartialMessage<ListUserPermissionsRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.users.ListUserPermissionsRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListUserPermissionsRequest {
+    return new ListUserPermissionsRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ListUserPermissionsRequest {
+    return new ListUserPermissionsRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ListUserPermissionsRequest {
+    return new ListUserPermissionsRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ListUserPermissionsRequest | PlainMessage<ListUserPermissionsRequest> | undefined, b: ListUserPermissionsRequest | PlainMessage<ListUserPermissionsRequest> | undefined): boolean {
+    return proto3.util.equals(ListUserPermissionsRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.users.Permission
+ */
+export class Permission extends Message<Permission> {
+  /**
+   * @generated from field: string id = 1;
+   */
+  id = "";
+
+  /**
+   * @generated from field: string name = 2;
+   */
+  name = "";
+
+  /**
+   * @generated from field: string display_name = 3;
+   */
+  displayName = "";
+
+  /**
+   * @generated from field: string description = 4;
+   */
+  description = "";
+
+  /**
+   * @generated from field: repeated string tags = 5;
+   */
+  tags: string[] = [];
+
+  constructor(data?: PartialMessage<Permission>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.users.Permission";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "display_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "description", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 5, name: "tags", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Permission {
+    return new Permission().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): Permission {
+    return new Permission().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): Permission {
+    return new Permission().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: Permission | PlainMessage<Permission> | undefined, b: Permission | PlainMessage<Permission> | undefined): boolean {
+    return proto3.util.equals(Permission, a, b);
+  }
+}
+
+/**
+ * @generated from message scalekit.v1.users.ListUserPermissionsResponse
+ */
+export class ListUserPermissionsResponse extends Message<ListUserPermissionsResponse> {
+  /**
+   * @generated from field: repeated scalekit.v1.users.Permission permissions = 1;
+   */
+  permissions: Permission[] = [];
+
+  constructor(data?: PartialMessage<ListUserPermissionsResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "scalekit.v1.users.ListUserPermissionsResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "permissions", kind: "message", T: Permission, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListUserPermissionsResponse {
+    return new ListUserPermissionsResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ListUserPermissionsResponse {
+    return new ListUserPermissionsResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ListUserPermissionsResponse {
+    return new ListUserPermissionsResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ListUserPermissionsResponse | PlainMessage<ListUserPermissionsResponse> | undefined, b: ListUserPermissionsResponse | PlainMessage<ListUserPermissionsResponse> | undefined): boolean {
+    return proto3.util.equals(ListUserPermissionsResponse, a, b);
   }
 }
 

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -7,7 +7,7 @@ export interface CreateUserRequest {
     lastName?: string;
   };
   metadata?: Record<string, string>;
-  sendActivationEmail?: boolean;
+  sendInvitationEmail?: boolean;
 }
 
 export interface UpdateUserRequest {

--- a/src/user.ts
+++ b/src/user.ts
@@ -25,7 +25,9 @@ import {
   ListOrganizationUsersRequest,
   ListOrganizationUsersResponse,
   CreateMembership,
-  UpdateMembership
+  UpdateMembership,
+  ResendInviteRequest,
+  ResendInviteResponse
 } from './pkg/grpc/scalekit/v1/users/users_pb';
 import { CreateUserRequest, UpdateUserRequest as UpdateUserRequestType } from './types/user';
 
@@ -67,8 +69,8 @@ export default class UserClient {
       user
     };
 
-    if (options.sendActivationEmail !== undefined) {
-      request.sendActivationEmail = options.sendActivationEmail;
+    if (options.sendInvitationEmail !== undefined) {
+      request.sendInvitationEmail = options.sendInvitationEmail;
     }
 
     const response = await this.coreClient.connectExec(
@@ -171,7 +173,7 @@ export default class UserClient {
    * @param {object} options The membership options
    * @param {string[]} options.roles The roles to assign
    * @param {Record<string, string>} options.metadata Optional metadata
-   * @param {boolean} options.sendActivationEmail Whether to send activation email
+   * @param {boolean} options.sendInvitationEmail Whether to send invitation email
    * @returns {Promise<CreateMembershipResponse>} The response with updated user
    */
   async createMembership(
@@ -180,7 +182,7 @@ export default class UserClient {
     options: {
       roles?: string[],
       metadata?: Record<string, string>,
-      sendActivationEmail?: boolean
+      sendInvitationEmail?: boolean
     } = {}
   ): Promise<CreateMembershipResponse> {
     const membership = new CreateMembership({
@@ -197,8 +199,8 @@ export default class UserClient {
       membership
     };
 
-    if (options.sendActivationEmail !== undefined) {
-      request.sendActivationEmail = options.sendActivationEmail;
+    if (options.sendInvitationEmail !== undefined) {
+      request.sendInvitationEmail = options.sendInvitationEmail;
     }
 
     return this.coreClient.connectExec(
@@ -286,6 +288,31 @@ export default class UserClient {
         pageSize: options?.pageSize,
         pageToken: options?.pageToken
       }
+    );
+  }
+
+  /**
+   * Resend an invitation to a user
+   * @param {string} organizationId The organization id
+   * @param {string} userId The user id
+   * @returns {Promise<ResendInviteResponse>} The response with the invite
+   */
+  async resendInvite(organizationId: string, userId: string): Promise<ResendInviteResponse> {
+    if (!organizationId) {
+      throw new Error('organizationId is required');
+    }
+    if (!userId) {
+      throw new Error('userId is required');
+    }
+
+    const request = new ResendInviteRequest({
+      organizationId,
+      id: userId
+    });
+
+    return this.coreClient.connectExec(
+      this.client.resendInvite,
+      request
     );
   }
 }

--- a/tests/users.test.ts
+++ b/tests/users.test.ts
@@ -7,6 +7,7 @@ describe('Users', () => {
   let client: ScalekitClient;
   let testOrg: string;
   let userId: string | null = null;
+  let sharedUserData: CreateUserRequest;
 
   beforeEach(async () => {
     // Use global client
@@ -14,6 +15,12 @@ describe('Users', () => {
     
     // Create test organization for each test
     testOrg = await TestOrganizationManager.createTestOrganization(client);
+    
+    // Create a shared user for testing
+    sharedUserData = TestDataGenerator.generateUserData();
+    const createResponse = await client.user.createUserAndMembership(testOrg, sharedUserData);
+    userId = createResponse.user?.id || null;
+    expect(userId).toBeDefined();
   });
 
   afterEach(async () => {
@@ -29,16 +36,6 @@ describe('Users', () => {
 
   describe('listOrganizationUsers', () => {
     it('should list users by organization', async () => {
-      // Create a user to ensure the organization has at least one user
-      const userData = TestDataGenerator.generateUserData();
-
-      const createResponse = await client.user.createUserAndMembership(testOrg, userData);
-      const createdUserId = createResponse.user?.id;
-      expect(createdUserId).toBeDefined();
-      
-      // Track user ID for cleanup
-      userId = createdUserId || null;
-
       // List users in the organization
       const usersList = await client.user.listOrganizationUsers(testOrg, TestDataGenerator.generatePaginationParams());
 
@@ -74,40 +71,38 @@ describe('Users', () => {
 
   describe('getUser', () => {
     it('should get user by ID', async () => {
-      // Create a user for testing
-      const userData = TestDataGenerator.generateUserData();
-
-      const createResponse = await client.user.createUserAndMembership(testOrg, userData);
-      const createdUserId = createResponse.user?.id;
-      expect(createdUserId).toBeDefined();
-      
-      // Track user ID for cleanup
-      userId = createdUserId || null;
-
       // Retrieve the user by ID
-      const user = await client.user.getUser(createdUserId!);
+      const user = await client.user.getUser(userId!);
       
       expect(user).toBeDefined();
       expect(user.user).toBeDefined();
-      expect(user.user?.id).toBe(createdUserId);
-      expect(user.user?.email).toBe(userData.email);
+      expect(user.user?.id).toBe(userId);
+      expect(user.user?.email).toBe(sharedUserData.email);
     });
   });
 
   describe('createUserAndMembership', () => {
     it('should create user and membership', async () => {
+      // Create a new user for this specific test
       const userData = TestDataGenerator.generateUserData();
+      let newUserId: string | null = null;
 
-      const response = await client.user.createUserAndMembership(testOrg, userData);
-      
-      expect(response).toBeDefined();
-      expect(response.user).toBeDefined();
-      expect(response.user?.id).toBeDefined();
-      expect(response.user?.email).toBe(userData.email);
-      expect(response.user?.metadata?.source).toBe('test');
-      
-      // Track user ID for cleanup
-      userId = response.user?.id || null;
+      try {
+        const response = await client.user.createUserAndMembership(testOrg, userData);
+        
+        expect(response).toBeDefined();
+        expect(response.user).toBeDefined();
+        expect(response.user?.id).toBeDefined();
+        expect(response.user?.email).toBe(userData.email);
+        expect(response.user?.metadata?.source).toBe('test');
+        
+        newUserId = response.user?.id || null;
+      } finally {
+        // Clean up the new user created in this test
+        if (newUserId) {
+          await TestUserManager.cleanupTestUser(client, testOrg, newUserId);
+        }
+      }
     });
 
     it('should throw error when email is missing', async () => {
@@ -129,26 +124,45 @@ describe('Users', () => {
 
   describe('updateUser', () => {
     it('should update user', async () => {
-      // Create a user for testing
-      const userData = TestDataGenerator.generateUserData();
-
-      const createResponse = await client.user.createUserAndMembership(testOrg, userData);
-      const createdUserId = createResponse.user?.id;
-      expect(createdUserId).toBeDefined();
-      
-      // Track user ID for cleanup
-      userId = createdUserId || null;
-
-      // Modify the user
+      // Modify the shared user
       const updateData = TestDataGenerator.generateUserUpdateData();
 
-      const updatedUser = await client.user.updateUser(createdUserId!, updateData);
+      const updatedUser = await client.user.updateUser(userId!, updateData);
       
       expect(updatedUser).toBeDefined();
       expect(updatedUser.user).toBeDefined();
-      expect(updatedUser.user?.id).toBe(createdUserId);
+      expect(updatedUser.user?.id).toBe(userId);
       expect(updatedUser.user?.userProfile?.firstName).toBe('Updated');
       expect(updatedUser.user?.userProfile?.lastName).toBe('Name');
+    });
+  });
+
+  describe('resendInvite', () => {
+    it('should resend invite to user', async () => {
+      // Resend invite to the shared user
+      const resendResponse = await client.user.resendInvite(testOrg, userId!);
+      
+      // Verify the response structure
+      expect(resendResponse).toBeDefined();
+      expect(resendResponse.invite).toBeDefined();
+      expect(resendResponse.invite?.userId).toBe(userId);
+      expect(resendResponse.invite?.organizationId).toBe(testOrg);
+      expect(resendResponse.invite?.status).toBe('PENDING_INVITE');
+      expect(resendResponse.invite?.createdAt).toBeDefined();
+      expect(resendResponse.invite?.expiresAt).toBeDefined();
+      expect(resendResponse.invite?.resentCount).toBe(1);
+    });
+
+    it('should throw error when organizationId is missing', async () => {
+      await expect(
+        client.user.resendInvite('', userId!)
+      ).rejects.toThrow('organizationId is required');
+    });
+
+    it('should throw error when userId is missing', async () => {
+      await expect(
+        client.user.resendInvite(testOrg, '')
+      ).rejects.toThrow('userId is required');
     });
   });
 }); 


### PR DESCRIPTION

Renames the sendActivationEmail option to sendInvitationEmail in user creation and membership methods for clarity and consistency. Adds a new resendInvite method to allow resending invitations to users.