### PR TITLE
Adding Release Pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,23 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
+      - name: Validate tag matches package.json version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)."
+            exit 1
+          fi
+
+      - name: Validate version is not already published on npm
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if npm view "@scalekit-sdk/node@$PKG_VERSION" version 2>/dev/null; then
+            echo "Version $PKG_VERSION is already published on npm. Bump the version before releasing."
+            exit 1
+          fi
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write # Required for npm provenance (OIDC)
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    environment: release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify no uncommitted build artifacts
+        run: |
+          git diff --exit-code lib/
+          untracked="$(git ls-files --others --exclude-standard lib/)"
+          if [ -n "$untracked" ]; then
+            echo "Untracked built files detected — commit the build output before releasing:"
+            echo "$untracked"
+            exit 1
+          fi
+
+      - name: Publish to npm
+        run: npm publish --tag latest --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,9 @@ jobs:
 
       - name: Validate version is not already published on npm
         run: |
+          PKG_NAME=$(node -p "require('./package.json').name")
           PKG_VERSION=$(node -p "require('./package.json').version")
-          if npm view "@scalekit-sdk/node@$PKG_VERSION" version 2>/dev/null; then
+          if npm view "$PKG_NAME@$PKG_VERSION" version 2>/dev/null; then
             echo "Version $PKG_VERSION is already published on npm. Bump the version before releasing."
             exit 1
           fi
@@ -50,13 +51,18 @@ jobs:
 
       - name: Verify no uncommitted build artifacts
         run: |
-          git diff --exit-code lib/
-          untracked="$(git ls-files --others --exclude-standard lib/)"
+          git diff --exit-code
+          untracked="$(git ls-files --others --exclude-standard)"
           if [ -n "$untracked" ]; then
-            echo "Untracked built files detected — commit the build output before releasing:"
+            echo "Untracked build artifacts detected — commit all generated output before releasing:"
             echo "$untracked"
             exit 1
           fi
 
       - name: Publish to npm
-        run: npm publish --tag latest --access public --provenance
+        run: |
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            npm publish --tag next --access public --provenance
+          else
+            npm publish --tag latest --access public --provenance
+          fi


### PR DESCRIPTION
Adding Release Pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated release workflow to publish packages to npm when GitHub releases are published.
  * Validates release tag matches package version and prevents publishing if the version already exists on npm.
  * Fails release on uncommitted or untracked changes after build to avoid shipping artifacts.
  * Publishes with provenance via OIDC and selects npm dist-tag (next for prereleases, latest otherwise).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->