### PR TITLE
feat: add searchUsers method to user client (FIN-271)

### DIFF
--- a/src/user.ts
+++ b/src/user.ts
@@ -26,6 +26,8 @@ import {
   GetUserResponse,
   ListUsersRequest,
   ListUsersResponse,
+  SearchUsersRequest,
+  SearchUsersResponse,
   UpdateUserRequest,
   UpdateUserResponse,
   User,
@@ -312,6 +314,54 @@ export default class UserClient {
     pageToken?: string;
   }): Promise<ListUsersResponse> {
     return this.coreClient.connectExec(this.client.listUsers, {
+      pageSize: options?.pageSize,
+      pageToken: options?.pageToken,
+    });
+  }
+
+  /**
+   * Searches users across your Scalekit environment using a query string.
+   *
+   * This method returns users that match the provided query, with optional pagination.
+   * Useful for building user search interfaces, lookup tools, and admin dashboards
+   * that need to find users by name, email, or other indexed attributes.
+   *
+   * @param {string} query - The search query string used to match users
+   * @param {object} [options] - Optional pagination parameters
+   * @param {number} [options.pageSize] - Number of users to return per page (valid range: 10-100, default: 10)
+   * @param {string} [options.pageToken] - Token for retrieving the next page of results.
+   *                                       Obtained from the previous response's nextPageToken.
+   *
+   * @returns {Promise<SearchUsersResponse>} Response containing:
+   *   - users: Array of user objects matching the query
+   *   - nextPageToken: Token for fetching the next page (empty if no more pages)
+   *   - prevPageToken: Token for fetching the previous page
+   *   - totalSize: Total number of users matching the query
+   *
+   * @example
+   * // Search users by query
+   * const response = await scalekitClient.user.searchUsers('john@example.com');
+   *
+   * console.log('Matched users:', response.users.length);
+   *
+   * @example
+   * // Search users with pagination
+   * const response = await scalekitClient.user.searchUsers('acme', {
+   *   pageSize: 25,
+   * });
+   *
+   * @see {@link https://docs.scalekit.com/apis/#tag/users | Search Users API}
+   * @see {@link listUsers} - List all users across the environment
+   */
+  async searchUsers(
+    query: string,
+    options?: {
+      pageSize?: number;
+      pageToken?: string;
+    },
+  ): Promise<SearchUsersResponse> {
+    return this.coreClient.connectExec(this.client.searchUsers, {
+      query,
       pageSize: options?.pageSize,
       pageToken: options?.pageToken,
     });


### PR DESCRIPTION
## Summary
- Adds `searchUsers(query, options?)` to the user client, wrapping the already-generated `SearchUsers` Connect RPC.
- Supports `pageSize` / `pageToken` for pagination, consistent with the existing `listUsers` method.

Closes FIN-271.

## Test plan
- [ ] `npm install`
- [ ] `npx tsc --noEmit`
- [ ] Manual smoke test against an environment using `scalekitClient.user.searchUsers('query', { pageSize: 10 })`.

<!-- generated-by-cyrus -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user search functionality allowing users to search across the environment with optional pagination controls for result management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/scalekit-sdk-node/pull/179)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->