### PR TITLE
feat(org): add slug support to createOrganization

### DIFF
--- a/src/organization.ts
+++ b/src/organization.ts
@@ -80,13 +80,16 @@ export default class OrganizationClient {
    */
   async createOrganization(
     name: string,
-    options?: { externalId?: string }
+    options?: { externalId?: string; slug?: string }
   ): Promise<CreateOrganizationResponse> {
     return this.coreClient.connectExec(this.client.createOrganization, {
       organization: {
         displayName: name,
         ...(options?.externalId && {
           externalId: options.externalId,
+        }),
+        ...(options?.slug && {
+          slug: options.slug,
         }),
       },
     });

--- a/tests/organization.test.ts
+++ b/tests/organization.test.ts
@@ -67,6 +67,28 @@ describe('Organizations', () => {
     });
   });
 
+  describe('createOrganization with slug', () => {
+    it('should create organization with slug and return it', async () => {
+      const slug = `test-slug-${Date.now()}`;
+      const response = await client.organization.createOrganization(
+        'Slug Test Org',
+        { slug }
+      );
+      expect(response.organization?.slug).toBe(slug);
+      await client.organization.deleteOrganization(response.organization!.id!);
+    });
+  });
+
+  describe('updateOrganization with slug', () => {
+    it('should update organization slug', async () => {
+      const slug = `upd-slug-${Date.now()}`;
+      const updated = await client.organization.updateOrganization(testOrg, {
+        slug,
+      });
+      expect(updated.organization?.slug).toBe(slug);
+    });
+  });
+
   describe('upsertUserManagementSettings', () => {
     it('should upsert max allowed users', async () => {
       const maxUsers = 50;


### PR DESCRIPTION
## Summary
- Add `slug?: string` to the `options` parameter of `createOrganization` — the field was already present in the generated gRPC types but not exposed in the convenience wrapper
- Wire `slug` into the gRPC request alongside `externalId`
- Add integration tests for create-with-slug and update-with-slug

## Test plan
- [ ] `createOrganization with slug` — creates org with slug, asserts `response.organization?.slug` matches
- [ ] `updateOrganization with slug` — updates slug on existing org, asserts new value is returned

Run with staging credentials:
```
SCALEKIT_ENVIRONMENT_URL=... SCALEKIT_CLIENT_ID=... SCALEKIT_CLIENT_SECRET=... \
  npm test -- --testPathPatterns=organization --testNamePattern=slug
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organizations can now be created with an optional slug identifier, enabling custom, memorable identifiers for each organization.
  * Existing organizations can now be updated with a new slug identifier at any time to reflect organizational changes.

* **Tests**
  * Added test coverage for organization slug creation and update functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/scalekit-sdk-node/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->