### PR TITLE
fix: default listScopedTools pageSize to 100

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -677,7 +678,8 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@bufbuild/protoc-gen-es": {
       "version": "2.11.0",
@@ -735,6 +737,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -1299,6 +1302,7 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1640,6 +1644,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2734,6 +2739,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -4382,6 +4388,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -4449,6 +4456,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -94,7 +94,7 @@ export default class ToolsClient {
       create(ListScopedToolsRequestSchema, {
         identifier,
         filter: create(ScopedToolFilterSchema, options.filter),
-        ...(options.pageSize !== undefined && { pageSize: options.pageSize }),
+        pageSize: options.pageSize ?? 100,
         ...(options.pageToken && { pageToken: options.pageToken }),
       })
     );

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -215,6 +215,35 @@ describe('Tools', () => {
         expect(error).toBeInstanceOf(ScalekitServerException);
       }
     });
+
+    it('should return more tools with default page size than explicit smaller page size', async () => {
+      const identifier = 'your_identifier';
+
+      try {
+        const smallPage = await client.tools.listScopedTools(identifier, {
+          filter: {
+            connectionNames: ['apifymcp'],
+          },
+          pageSize: 10,
+        });
+
+        const defaultPage = await client.tools.listScopedTools(identifier, {
+          filter: {
+            connectionNames: ['apifymcp'],
+          },
+        });
+
+        expect(defaultPage).toBeDefined();
+        expect(defaultPage.tools).toBeDefined();
+
+        // the default page size is 100 in the implementation, so this should return more or equal number of tools than the small page size of 10
+        expect(defaultPage.tools.length).toBeGreaterThanOrEqual(
+          smallPage.tools.length
+        );
+      } catch (error: unknown) {
+        expect(error).toBeInstanceOf(ScalekitServerException);
+      }
+    });
   });
 
   describe('executeTool', () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -217,7 +217,7 @@ describe('Tools', () => {
     });
 
     it('should return more tools with default page size than explicit smaller page size', async () => {
-      const identifier = 'your_identifier';
+      const identifier = 'akshay.parihar';
 
       try {
         const smallPage = await client.tools.listScopedTools(identifier, {
@@ -235,11 +235,16 @@ describe('Tools', () => {
 
         expect(defaultPage).toBeDefined();
         expect(defaultPage.tools).toBeDefined();
+        expect(smallPage).toBeDefined();
+        expect(smallPage.tools).toBeDefined();
 
-        // the default page size is 100 in the implementation, so this should return more or equal number of tools than the small page size of 10
-        expect(defaultPage.tools.length).toBeGreaterThanOrEqual(
-          smallPage.tools.length
-        );
+        // If there are more than 10 tools, the default (100) should return more than the small page (10)
+        // If there are 10 or fewer tools, both should return the same count
+        if (smallPage.nextPageToken) {
+          expect(defaultPage.tools.length).toBeGreaterThan(smallPage.tools.length);
+        } else {
+          expect(defaultPage.tools.length).toBeGreaterThanOrEqual(smallPage.tools.length);
+        }
       } catch (error: unknown) {
         expect(error).toBeInstanceOf(ScalekitServerException);
       }


### PR DESCRIPTION
## Summary

This PR improves the default pagination behavior for `tools.listScopedTools()` by defaulting `pageSize` to `100` when omitted.

Previously, callers relying on the backend default page size could receive incomplete tool discovery results for connectors exposing more than 10 tools.

## Changes

* Default `pageSize` to `100` in `listScopedTools()`
* Added regression test coverage for default pagination behavior

Fixes #175