### PR TITLE
[SK-623] chore(deps): bump 5 low-risk Node deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,18 +14,18 @@
         "@connectrpc/connect-node": "^2.1.1",
         "axios": "^1.13.5",
         "jose": "^5.6.3",
-        "qs": "^6.14.2"
+        "qs": "^6.15.2"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.36.0",
         "@bufbuild/protoc-gen-es": "2.11.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "^20.14.10",
-        "@types/qs": "^6.9.15",
+        "@types/node": "^20.19.43",
+        "@types/qs": "^6.15.1",
         "dotenv": "^16.4.7",
         "jest": "^29.7.0",
-        "prettier": "^3.4.2",
-        "ts-jest": "^29.4.0",
+        "prettier": "^3.8.4",
+        "ts-jest": "^29.4.11",
         "ts-node": "^10.9.2",
         "typescript": "^5.5.3"
       },
@@ -1294,9 +1294,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
-      "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1304,9 +1304,9 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3825,9 +3825,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3906,9 +3906,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -4298,19 +4298,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.8.0",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -4327,7 +4327,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -4351,9 +4351,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -38,20 +38,20 @@
     "@connectrpc/connect-node": "^2.1.1",
     "axios": "^1.13.5",
     "jose": "^5.6.3",
-    "qs": "^6.14.2"
+    "qs": "^6.15.2"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.36.0",
     "@bufbuild/protoc-gen-es": "2.11.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "^20.14.10",
-    "@types/qs": "^6.9.15",
+    "@types/node": "^20.19.43",
+    "@types/qs": "^6.15.1",
     "dotenv": "^16.4.7",
     "jest": "^29.7.0",
-    "ts-jest": "^29.4.0",
+    "prettier": "^3.8.4",
+    "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
-    "typescript": "^5.5.3",
-    "prettier": "^3.4.2"
+    "typescript": "^5.5.3"
   },
   "bugs": {
     "url": "https://github.com/scalekit-inc/scalekit-sdk-node/issues"


### PR DESCRIPTION
## Summary

Linear ticket: [SK-623](https://linear.app/scalekit/issue/SK-623/choredeps-bump-5-low-risk-node-deps)

Bumps 5 low-risk patch/minor dependencies with no breaking changes:

| Package | From | To | Type |
|---------|------|----|------|
| `qs` | 6.14.2 | 6.15.2 | dependency |
| `@types/qs` | 6.14.0 | 6.15.1 | devDependency |
| `prettier` | 3.8.1 | 3.8.4 | devDependency |
| `ts-jest` | 29.4.6 | 29.4.11 | devDependency |
| `@types/node` | 20.19.30 | 20.19.43 | devDependency |

## Notes

- All upgrades are patch or minor within their current major version — no breaking changes expected.
- TypeScript lint (`tsc --noEmit`) passes clean.
- Integration tests require `SCALEKIT_ENVIRONMENT_URL` env var and fail in this environment independent of these changes (pre-existing condition).

## Test plan

- [x] `npm run lint` — passes clean
- [x] `package-lock.json` refreshed consistently

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUXNcnRGWpw5HaQbGJKeWP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated internal dependencies to latest patch and minor versions for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->