### PR TITLE
[SK-632] chore(deps): bump @types/node from 20 to 25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@bufbuild/buf": "^1.70.0",
         "@bufbuild/protoc-gen-es": "^2.12.0",
         "@types/jest": "^30.0.0",
-        "@types/node": "^20.19.43",
+        "@types/node": "^25.9.3",
         "@types/qs": "^6.15.1",
         "dotenv": "^17.4.2",
         "jest": "^30.4.2",
@@ -1439,13 +1439,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/qs": {
@@ -5123,9 +5123,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@bufbuild/buf": "^1.70.0",
     "@bufbuild/protoc-gen-es": "^2.12.0",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20.19.43",
+    "@types/node": "^25.9.3",
     "@types/qs": "^6.15.1",
     "dotenv": "^17.4.2",
     "jest": "^30.4.2",


### PR DESCRIPTION
## Summary

Upgrades `@types/node` (devDependency) from v20 to v25.

| Package | From | To |
|---|---|---|
| `@types/node` | 20.19.43 | 25.9.3 |

**Linear:** https://linear.app/scalekit/issue/SK-632

## Changes

- Bumped `@types/node` range in `package.json` from `^20.19.43` to `^25.9.3`
- Updated `package-lock.json`

## Notes

- `@types/node` is a `devDependency` — not shipped to SDK consumers
- Only Node.js built-in API used in this SDK is `crypto.timingSafeEqual` (stable since Node 6, unchanged in Node 25)
- CI runs Node 20.x, 22.x, 24.x — `@types/node@25` types are additive and backward-compatible
- `tsc --noEmit` (lint) passes cleanly after upgrade

---
_Generated by [Claude Code](https://claude.ai/code/session_018nZJc3CVZ57vqBuFBLBFFE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies.

*Note: This update contains no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->