### PR TITLE
[SK-633] chore(deps): bump jose from 5 to 6

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,11 +6,12 @@ module.exports = {
   setupFilesAfterEnv: ['./tests/setup.ts'],
   transform: {
     '^.+\\.ts?$': 'ts-jest',
+    '^.+\\.js$': ['ts-jest', { diagnostics: false, tsconfig: { allowJs: true } }],
   },
+  transformIgnorePatterns: ['/node_modules/(?!(jose)/)'],
   moduleNameMapper: {
-    '^jose': require.resolve('jose'),
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   testTimeout: 30000,
   maxWorkers: 1,
-}; 
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@connectrpc/connect": "^2.1.1",
         "@connectrpc/connect-node": "^2.1.1",
         "axios": "^1.17.0",
-        "jose": "^5.6.3",
+        "jose": "^6.2.3",
         "qs": "^6.15.2"
       },
       "devDependencies": {
@@ -3871,9 +3871,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@connectrpc/connect": "^2.1.1",
     "@connectrpc/connect-node": "^2.1.1",
     "axios": "^1.17.0",
-    "jose": "^5.6.3",
+    "jose": "^6.2.3",
     "qs": "^6.15.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Upgrades `jose` (production dependency) from v5 to v6.

| Package | From | To |
|---|---|---|
| `jose` | 5.10.0 | 6.2.3 |

**Linear:** https://linear.app/scalekit/issue/SK-633

## Changes

- Bumped `jose` range in `package.json` from `^5.6.3` to `^6.2.3`
- Updated `package-lock.json`

## Notes

- jose v6 uses Web Crypto API exclusively; Node 18+ has `globalThis.crypto` built-in (project requires ≥ 18.14.1 ✅)
- All functions used by this SDK — `decodeJwt`, `createLocalJWKSet`, `jwtVerify`, `JWK` type — are present in the jose v6 root export with compatible signatures
- `tsc --noEmit` (lint) passes cleanly after upgrade — verified before creating PR

---
_Generated by [Claude Code](https://claude.ai/code/session_018nZJc3CVZ57vqBuFBLBFFE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to handle TypeScript and JavaScript file transforms
  * Upgraded `jose` package dependency to version 6.2.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->