### PR TITLE
[SK-643] chore(deps): bump typescript from 5 to 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "prettier": "^3.8.4",
         "ts-jest": "^29.4.11",
         "ts-node": "^10.9.2",
-        "typescript": "^5.5.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=18.14.1"
@@ -5095,9 +5095,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "prettier": "^3.8.4",
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
-    "typescript": "^5.5.3"
+    "typescript": "^6.0.3"
   },
   "bugs": {
     "url": "https://github.com/scalekit-inc/scalekit-sdk-node/issues"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "typeRoots": ["src/types", "node_modules/@types"],
-    "moduleResolution": "Node"
+    "types": ["node"],
+    "moduleResolution": "Node",
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "outDir": "lib",
+    "rootDir": "src",
     "strict": true,
     "sourceMap": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

Upgrades `typescript` (devDependency) from v5 to v6.

| Package | From | To |
|---|---|---|
| `typescript` | ^5.5.3 | ^6.0.3 |

**Linear:** https://linear.app/scalekit/issue/SK-643

## Changes

- Bumped `typescript` range in `package.json` from `^5.5.3` to `^6.0.3`
- Updated `package-lock.json`
- Added `"ignoreDeprecations": "6.0"` to `tsconfig.json` — TS6 deprecated `moduleResolution=node10`; this silences the error while keeping identical behaviour (removal scheduled for TS7)
- Added `"types": ["node"]` to `tsconfig.json` — TS6 no longer auto-includes `@types/node` when `typeRoots` is set; explicit opt-in restores access to `os`, `process`, `Buffer`, `crypto`, etc.

## Notes

- `tsc --noEmit` (lint) passes cleanly after upgrade — verified before creating PR
- No runtime behaviour changes: `ignoreDeprecations` is a compiler-only flag; `types: ["node"]` was already implicitly true under TS5

---
_Generated by [Claude Code](https://claude.ai/code/session_018nZJc3CVZ57vqBuFBLBFFE)_