### PR TITLE
chore: release v2.6.3

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -70,7 +70,7 @@ class CoreClient {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         this.sdkVersion = `Scalekit-Node/${require('../package.json').version}`;
         // YYYYMMDD
-        this.apiVersion = '20260522';
+        this.apiVersion = '20260612';
         this.userAgent = `${this.sdkVersion} Node/${process.version} (${process.platform}; ${os_1.default.arch()})`;
         this.axios = axios_1.default.create({ baseURL: envUrl });
         this.axios.interceptors.request.use((config) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@scalekit-sdk/node",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@scalekit-sdk/node",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "license": "ISC",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.6.2",
+  "version": "2.6.3",
   "name": "@scalekit-sdk/node",
   "description": "Official Scalekit Node SDK",
   "main": "lib/index.js",

--- a/src/core.ts
+++ b/src/core.ts
@@ -41,7 +41,7 @@ export default class CoreClient {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   public sdkVersion = `Scalekit-Node/${(require('../package.json') as { version: string }).version}`;
   // YYYYMMDD
-  public apiVersion = '20260522';
+  public apiVersion = '20260612';
   public userAgent = `${this.sdkVersion} Node/${process.version} (${
     process.platform
   }; ${os.arch()})`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "typeRoots": ["src/types", "node_modules/@types"],
     "types": ["node"],
     "moduleResolution": "Node",
-    "ignoreDeprecations": "5.0"
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "typeRoots": ["src/types", "node_modules/@types"],
     "types": ["node"],
     "moduleResolution": "Node",
-    "ignoreDeprecations": "6.0"
+    "ignoreDeprecations": "5.0"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

- Bump version `2.6.2` → `2.6.3`
- Fix `tsconfig.json` `ignoreDeprecations` value from `"6.0"` to `"5.0"` to resolve TypeScript 6 build error (`TS5103: Invalid value for '--ignoreDeprecations'`)

## Test plan

- [x] Build passes (`npm run build`)
- [x] 236/243 tests pass (7 pre-existing integration test failures unrelated to this release — Gmail OAuth connection test data missing in test env)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Package version bumped to 2.6.3.
  * API version updated for compatibility with current backend services; this ensures requests use the latest API specification, improving compatibility and reducing potential integration issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->