### PR TITLE
SK-1510: bump axios to fix form-data CRLF injection + axios advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bufbuild/protobuf": "^2.12.0",
         "@connectrpc/connect": "^2.1.1",
         "@connectrpc/connect-node": "^2.1.1",
-        "axios": "^1.17.0",
+        "axios": "^1.19.0",
         "jose": "^6.2.3",
         "qs": "^6.15.2"
       },
@@ -1933,13 +1933,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -2774,16 +2774,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3001,9 +3001,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@bufbuild/protobuf": "^2.12.0",
     "@connectrpc/connect": "^2.1.1",
     "@connectrpc/connect-node": "^2.1.1",
-    "axios": "^1.17.0",
+    "axios": "^1.19.0",
     "jose": "^6.2.3",
     "qs": "^6.15.2"
   },


### PR DESCRIPTION
## Summary

- `axios@1.17.0` (previous floor `^1.17.0`) sat inside axios's own vulnerable range `1.0.0 - 1.17.0` (prototype pollution via auth/nested option objects, `maxBodyLength` bypass on streamed uploads, `NO_PROXY` bypass for `0.0.0.0`, among others).
- It also pulled in `form-data@4.0.5`, vulnerable to CRLF injection via unescaped multipart field names/filenames.
- Bumped floor to `axios@^1.19.0`, which resolves `form-data` to the patched `4.0.6`.

## Verification

- `npm audit`: axios/form-data no longer listed.
- `npm ls axios form-data`: confirms `axios@1.19.0` → `form-data@4.0.6`.
- `tsc --noEmit` clean, `npm run build` succeeds (no `lib/` diff — axios isn't part of compiled output).
- Full test suite: 301/310 passing. The 8 failures (Freshdesk connected-account/actions/connection live-integration tests) are pre-existing — confirmed identical failures on `main` without this change (live external test-account state, unrelated to this dependency bump).

## Out of scope

Remaining Dependabot findings (`@babel/core`, `brace-expansion`, `js-yaml`) are transitive devDependencies of `jest`/`ts-jest` only — dev tooling, never shipped to consumers of the published package.

Linear: SK-1510

🤖 Generated with [Claude Code](https://claude.com/claude-code)