### PR TITLE
docs: Clarify that the GitHub Release must be published

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,8 @@ Package: `@scalekit-sdk/node` on npm. Workflow: `.github/workflows/release.yml`.
 1. Bump the version in `package.json` and `package-lock.json`. Use a minor or patch bump.
 2. Review the unreleased changes. If proto or generated API files changed, extra generation steps apply. Those steps are not documented yet. Do not invent them. Ask before you regenerate.
 3. Merge the release branch to `main`.
-4. Create a git tag that matches the version (`v2.12.0` for `2.12.0`). Draft a GitHub Release for that tag.
-5. Publishing does not start on its own. Open the Actions run for the release workflow. Any peer can approve it. The `release` environment gates deploy.
+4. Create a git tag that matches the version (`v2.12.0` for `2.12.0`). Create and publish a GitHub Release for that tag.
+5. After publication, the Release workflow starts automatically. Open the Actions run and obtain approval for the `release` environment.
 6. After approval, the workflow publishes to npm.
 
 <!-- MANUAL ADDITIONS END -->


### PR DESCRIPTION
## Summary

Addresses CodeRabbit on #214.

A draft GitHub Release does not start `.github/workflows/release.yml`. That workflow listens for `release` `published`. This change says to publish the release, then approve the Actions `release` environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scalekit-inc/codesmith/scalekit-sdk-node/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789712108&installation_model_id=431434&pr_number=215&repository=scalekit-inc%2Fscalekit-sdk-node&return_to=https%3A%2F%2Fgithub.com%2Fscalekit-inc%2Fscalekit-sdk-node%2Fpull%2F215&signature=21d63dd92d199a4db7b8ebdda99ab5802b99de02b2855835af2590fcbd48c229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release instructions to include creating and publishing a GitHub Release.
  * Added guidance for approving the automatically triggered release workflow.
  * Removed outdated steps for draft releases, manual workflow starts, and peer approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->